### PR TITLE
Fixed https://github.com/protz/GMail-Conversation-View/issues/409

### DIFF
--- a/modules/message.js
+++ b/modules/message.js
@@ -103,7 +103,7 @@ function addMsgListener(aMessage) {
 }
 
 let isOSX = ("nsILocalFileMac" in Ci);
-let isWindows = ("@mozilla.org/windows-registry-key;1" in CC);
+let isWindows = ("@mozilla.org/windows-registry-key;1" in Cc);
 
 function isAccel (event) (isOSX && event.metaKey || event.ctrlKey)
 


### PR DESCRIPTION
added firing "msgLoaded" event after an email in a conversation has been expanded for the first time
