### PR TITLE
Fix mojibake in bugzilla mail snippet

### DIFF
--- a/modules/plugins/helpers.js
+++ b/modules/plugins/helpers.js
@@ -121,7 +121,7 @@ let PluginHelpers = {
       ];
       let o = {};
       for each (let k in keys)
-        o[k] = aMimeMsg.get("x-bugzilla-"+k); 
+        o[k] = GlodaUtils.deMime(aMimeMsg.get("x-bugzilla-"+k));
       return o;
     }
 


### PR DESCRIPTION
This happens when there are Chinese characters in X-Bugzilla-\* headers.

This fix needs deleting global-messages-db.sqlite to take effect.

Thanks for your great work!
