### PR TITLE
Fix validation failure of inline-PGP sign.

### DIFF
--- a/modules/plugins/enigmail.js
+++ b/modules/plugins/enigmail.js
@@ -346,6 +346,9 @@ let enigmailHook = {
         let plainText = aEditor.value;
         let charset = "UTF-8";
         origText = plainText;
+        if (!(sendFlags & ENCRYPT)) {
+          plainText = simpleWrap(plainText);
+        }
         plainText= EnigmailCommon.convertFromUnicode(plainText, charset);
         let cipherText = enigmailSvc.encryptMessage(window, uiFlags, null,
                            plainText, fromAddr, toAddr, bccAddr,


### PR DESCRIPTION
If a message has long lines, wrapping the message after inline-PGP
signing breaks the validity of the signature.
A message should be wrapped before inline-PGP signing.
