### PR TITLE
Add error handling of encryption/signing messages.

### DIFF
--- a/modules/plugins/enigmail.js
+++ b/modules/plugins/enigmail.js
@@ -365,6 +365,14 @@ let enigmailHook = {
           cipherText = EnigmailCommon.convertToUnicode(cipherText, charset);
           aEditor.value = cipherText;
         }
+        else {
+          // Encryption/signing failed
+          let msg = EnigmailCommon.getString("signFailed") + "\n"
+                  + errorMsgObj.value;
+          aStatus.canceled = !EnigmailCommon.confirmDlg(window, msg,
+            EnigmailCommon.getString("msgCompose.button.sendUnencrypted"));
+          return aStatus;
+        }
       }
 
       if ((!(sendFlags & nsIEnigmail.SAVE_MESSAGE)) &&
@@ -385,8 +393,8 @@ let enigmailHook = {
       if (EnigmailCommon.enigmailSvc && EnigmailCommon.enigmailSvc.initializationError) {
         msg += "\n"+EnigmailCommon.enigmailSvc.initializationError;
       }
-      aStatus.canceled =
-        !EnigmailCommon.confirmDlg(window, msg, EnigmailCommon.getString("msgCompose.button.sendUnencrypted"));
+      aStatus.canceled = !EnigmailCommon.confirmDlg(window, msg,
+        EnigmailCommon.getString("msgCompose.button.sendUnencrypted"));
     }
     return aStatus;
   },


### PR DESCRIPTION
I found a case where sending a message fails with no warning.

This error handling is used in cases where recipients keys are not found
and using Enigmail under 1.3.3, etc.

Line 396-397 change is just reformat.
