### PR TITLE
Focus corresponding field when adding cc or bcc in quick reply

### DIFF
--- a/content/stub.compose-ui.js
+++ b/content/stub.compose-ui.js
@@ -243,11 +243,13 @@ function changeComposeFields(aMode) {
 function showCc(event) {
   $(".ccList, .editCcList").css("display", "");
   $(".showCc").hide();
+  editFields("cc");
 }
 
 function showBcc(event) {
   $(".bccList, .editBccList").css("display", "");
   $(".showBcc").hide();
+  editFields("bcc");
 }
 
 function editFields(aFocusId) {


### PR DESCRIPTION
As discussed in https://github.com/protz/GMail-Conversation-View/issues/466
