### PR TITLE
Fix pgp/mime initialize.

### DIFF
--- a/modules/plugins/enigmail.js
+++ b/modules/plugins/enigmail.js
@@ -121,7 +121,13 @@ window.addEventListener("load", function () {
     }
 
     let w = getMail3Pane();
-    w.document.getElementById("messagepane").setAttribute("src", "enigmail:dummy");
+    let iframe = w.document.createElement("iframe");
+    iframe.addEventListener("load", function () {
+      iframe.parentNode.removeChild(iframe);
+    }, true);
+    iframe.setAttribute("src", "enigmail:dummy");
+    iframe.style.display = "none";
+    w.document.getElementById("messagepane").appendChild(iframe);
   }
 }, false);
 


### PR DESCRIPTION
This fixes an issue that the start up page is not shown when Thunderbird
lanches. We use a dummy iframe for pgp/mime initialize.

Although this patch is a bit more complicated, do you have smarter solutions?
