### PR TITLE
Followup fix for display security info

### DIFF
--- a/modules/plugins/enigmail.js
+++ b/modules/plugins/enigmail.js
@@ -251,18 +251,17 @@ function prepareForHdrIconsOnFocus(aMessage) {
     updateHdrIcons = w.Enigmail.hdrView.updateHdrIcons;
     w.Enigmail.hdrView._oldUpdateHdrIcons = updateHdrIcons;
   }
-  let updateHdrIconsForMessage;
+  let updateHdrIconsForMessage, self, args;
   w.Enigmail.hdrView.updateHdrIcons = function () {
-    let [self, args] = [this, arguments];
+    [self, args] = [this, arguments];
     (updateHdrIconsForMessage = function () {
       updateHdrIcons.apply(self, args);
     })();
   }
   aMessage._domNode.addEventListener("focus", function () {
+    w.Enigmail.hdrView.statusBarHide();
     if (updateHdrIconsForMessage) {
       updateHdrIconsForMessage();
-    } else {
-      w.Enigmail.hdrView.statusBarHide();
     }
   }, true);
 }


### PR DESCRIPTION
I'm sorry, I found some issues. Please check followup fix.

Fix a defect that bottom right security icons aren't updated correctly
on focusing a message again.

Fix a defect that "self" and "args" local variables in
updateHdrIconsForMessage sometimes disappear.
