### PR TITLE
Quick reply textarea under conversation header

### DIFF
--- a/skin/conversation.css
+++ b/skin/conversation.css
@@ -96,7 +96,7 @@ button img {
   top: 0;
   left: 0;
   width: 100%;
-  z-index: 100;
+  z-index: 150;
   -moz-box-shadow: 0 0 2px rgba(0,0,0,0.25);
 }
 


### PR DESCRIPTION
When I resize quick reply textarea larger and scroll view, textarea is over the conversation header as below capture.
http://imgur.com/IiUsE

I think it would be nice if textarea would be under the conversation header.

z-index of textarea is 100.
https://github.com/protz/GMail-Conversation-View/blob/master/skin/quickreply.css#L105
If there is other proper fix, that's OK.
