### PR TITLE
Fix new arrived message silently marked as read

### DIFF
--- a/content/stub.xhtml
+++ b/content/stub.xhtml
@@ -521,7 +521,8 @@
     // unread message.
     function markReadInView() {
       document.removeEventListener("scroll", markReadInView, false);
-      window.setTimeout(function () {
+      clearTimeout(markReadInView.timeout);
+      markReadInView.timeout = setTimeout(function () {
         document.addEventListener("scroll", markReadInView, false);
       }, 200);
       if (!Conversations.currentConversation)

--- a/modules/conversation.js
+++ b/modules/conversation.js
@@ -817,6 +817,7 @@ Conversation.prototype = {
         for each ([_i, m] in Iterator(aMessages))];
 
       let w = this._htmlPane.contentWindow;
+      w.clearTimeout(w.markReadInView.timeout);
       [w.document.removeEventListener(x, w.markReadInView, false)
         for each ([, x] in Iterator(["mouseover", "focus", "scroll"]))];
 


### PR DESCRIPTION
Remove event listeners while appending a new message.
This patch seems to fix the issue.

Add focus event for keyboard shortcut.
But I think it might not sufficient for keyboard shortcut.

Could you check it?
