### PR TITLE
Followup display security info for Enigmail

### DIFF
--- a/modules/plugins/enigmail.js
+++ b/modules/plugins/enigmail.js
@@ -129,6 +129,54 @@ window.addEventListener("load", function () {
     iframe.setAttribute("src", "enigmail:dummy");
     iframe.style.display = "none";
     w.document.getElementById("messagepane").appendChild(iframe);
+
+    // Override updateSecurityStatus for showing security info properly
+    // when plural messages in a thread are streamed at one time.
+    let messagepane = w.document.getElementById("messagepane");
+    messagepane.addEventListener("load", function _overrideUpdateSecurity() {
+      messagepane.removeEventListener("load", _overrideUpdateSecurity, true);
+      let w = getMail3Pane();
+      w._encryptedMimeMessages = [];
+      w.messageHeaderSink.enigmailPrepSecurityInfo();
+
+      // EnigMimeHeaderSink.prototype in enigmailMsgHdrViewOverlay.js
+      let enigMimeHeaderSinkPrototype =
+        Object.getPrototypeOf(w.messageHeaderSink.securityInfo);
+      enigMimeHeaderSinkPrototype
+        .updateSecurityStatus = function _updateSecurityStatus_patched(uriSpec) {
+        let message;
+        // multipart/encrypted message doesn't have uriSpec.
+        if (!uriSpec) {
+          // possible to get a wrong message
+          message = w._encryptedMimeMessages.shift();
+          // Use a nsIURI object to identify the message correctly.
+          // Enigmail patch is required.
+          let uri = arguments[8];
+          if (uri) {
+            let msgHdr = uri.QueryInterface(Ci.nsIMsgMessageUrl).messageHeader;
+            uriSpec = msgHdrGetUri(msgHdr);
+          }
+        }
+        if (uriSpec) {
+          for each (let [, x] in Iterator(w._currentConversation.messages)) {
+            if (x.message._uri == uriSpec) {
+              message = x.message;
+              break;
+            }
+          }
+        }
+        let args = Array.prototype.slice.call(arguments, 1);
+        let updateHdrIcons = function () {
+          w.Enigmail.hdrView.updateHdrIcons.apply(w.Enigmail.hdrView, args);
+        };
+        if (!message) {
+          Log.error("Message for the security info not found!\n");
+          updateHdrIcons();
+          return;
+        }
+        showHdrIconsOnStreamed(message, updateHdrIcons);
+      }
+    }, true);
   }
 }, false);
 
@@ -218,9 +266,11 @@ function tryEnigmail(bodyElement, aMsgWindow, aMessage) {
       Log.error("Enigmail error: "+exitCodeObj.value+" --- "+errorMsgObj.value+"\n");
     }
     let w = topMail3Pane(aMessage);
-    w.Enigmail.hdrView.updateHdrIcons(exitCodeObj.value, statusFlagsObj.value,
-      keyIdObj.value, userIdObj.value, sigDetailsObj.value, errorMsgObj.value,
-      blockSeparationObj.value);
+    showHdrIconsOnStreamed(aMessage, function () {
+      w.Enigmail.hdrView.updateHdrIcons(exitCodeObj.value, statusFlagsObj.value,
+        keyIdObj.value, userIdObj.value, sigDetailsObj.value, errorMsgObj.value,
+        blockSeparationObj.value);
+    });
     return statusFlagsObj.value;
   } catch (ex) {
     dumpCallStack(ex);
@@ -242,43 +292,63 @@ function verifyAttachments(aMessage) {
   });
 };
 
-// Preserve the security info in message event handler to display it
-// when focusing on the message again.
-function prepareForHdrIconsOnFocus(aMessage) {
+// Prepare for showing security info later
+function prepareForShowHdrIcons(aMessage, aHasEnc) {
   let w = topMail3Pane(aMessage);
-  let updateHdrIcons = w.Enigmail.hdrView._oldUpdateHdrIcons;
-  if (!updateHdrIcons) {
-    updateHdrIcons = w.Enigmail.hdrView.updateHdrIcons;
-    w.Enigmail.hdrView._oldUpdateHdrIcons = updateHdrIcons;
-  }
-  let updateHdrIconsForMessage, self, args;
-  w.Enigmail.hdrView.updateHdrIcons = function () {
-    [self, args] = [this, arguments];
-    (updateHdrIconsForMessage = function () {
-      updateHdrIcons.apply(self, args);
-    })();
-  }
+  let conversation = aMessage._conversation;
+
+  // w.Conversations.currentConversation is assined when conversation
+  // _onComplete(), but we need currentConversation in
+  // updateSecurityStatus() which is possible to be called before
+  // _onComplete().
+  w._currentConversation = conversation;
+
+  if (conversation._focusThis === undefined)
+    conversation._focusThis = conversation._tellMeWhoToScroll();
+  if (aHasEnc)
+    w._encryptedMimeMessages.push(aMessage);
+
+  // The security info is stored in the message's _updateHdrIcons
+  // to show it when focusing on the message again.
   aMessage._domNode.addEventListener("focus", function () {
     w.Enigmail.hdrView.statusBarHide();
-    if (updateHdrIconsForMessage) {
-      updateHdrIconsForMessage();
+    if (aMessage._updateHdrIcons) {
+      aMessage._updateHdrIcons();
     }
   }, true);
 }
 
+// Show security info only if the message is focused.
+function showHdrIconsOnStreamed(aMessage, updateHdrIcons) {
+  let w = topMail3Pane(aMessage);
+  let { _domNode: node, _conversation: conversation } = aMessage;
+  let focused = (node == node.ownerDocument.activeElement);
+  if (!focused) {
+    let messageNodes = conversation._domNode
+      .getElementsByClassName(aMessage.cssClass);
+    focused = (node == messageNodes[conversation._focusThis]);
+  }
+  if (focused)
+    updateHdrIcons();
+
+  // Prepare for showing on focus.
+  aMessage._updateHdrIcons = updateHdrIcons;
+}
+
 // Override treeController defined in enigmailMessengerOverlay.js
 // not to hide status bar when multiple messages are selected.
-function patchDecryptButtonController(aWindow) {
+// Remove unwanted event listeners.
+function patchForShowSecurityInfo(aWindow) {
   let w = aWindow;
   if (w._newTreeController)
     return;
 
-  let treeController =
+  let oldTreeController =
     w.top.controllers.getControllerForCommand("button_enigmail_decrypt");
-  w.top.controllers.removeController(treeController);
-  let newTreeController = {};
-  [newTreeController[i] = x for each([i, x] in Iterator(treeController))];
-  newTreeController.isCommandEnabled = function () {
+  w.top.controllers.removeController(oldTreeController);
+  let treeController = {};
+  [treeController[i] = x for each([i, x] in Iterator(oldTreeController))];
+  treeController.isCommandEnabled = function () {
     if (w.gFolderDisplay.messageDisplay.visible) {
       if (w.gFolderDisplay.selectedCount == 0) {
         w.Enigmail.hdrView.statusBarHide();
@@ -287,8 +357,14 @@ function patchDecryptButtonController(aWindow) {
     }
     w.Enigmail.hdrView.statusBarHide();
   };
-  w.top.controllers.appendController(newTreeController);
-  w._newTreeController = newTreeController;
+  w.top.controllers.appendController(treeController);
+  w._newTreeController = treeController;
+
+  // Event listeners are added in enigmailMsgHdrViewOverlay.js,
+  // but not needed. These display security info incorrectly when
+  // resizing message view.
+  w.removeEventListener('messagepane-hide', w.Enigmail.hdrView.msgHdrViewHide, true);
+  w.removeEventListener('messagepane-unhide', w.Enigmail.hdrView.msgHdrViewUnide, true);
 }
 
 let enigmailHook = {
@@ -314,8 +390,8 @@ let enigmailHook = {
         aMessage._domNode.classList.add("signed");
 
       verifyAttachments(aMessage);
-      prepareForHdrIconsOnFocus(aMessage);
-      patchDecryptButtonController(w);
+      prepareForShowHdrIcons(aMessage, hasEnc);
+      patchForShowSecurityInfo(w);
     }
   },
 


### PR DESCRIPTION
This is some refactoring of #483. Could you check it?

When plural unread messages in a thread are streamed at one time,
security info isn't displayed properly. Fix the issue.

Enigmail patch is also required.
See https://www.mozdev.org/bugs/show_bug.cgi?id=24519

Fix an issue that resizing message view causes to show
security info incorrectly.

There are some cleanups.
