### PR TITLE
Mark as read on scroll using keyboard shortcut

### DIFF
--- a/content/stub.xhtml
+++ b/content/stub.xhtml
@@ -519,11 +519,27 @@
 
     // Mark a message as read if a user scrolls past top and bottom of an
     // unread message.
-    function markReadInView() {
-      document.removeEventListener("scroll", markReadInView, false);
+    function markReadInView(event) {
+      if (event.type == "keydown") {
+        // for scroll by keyboard shortcut
+        switch (event.which) {
+          case KeyEvent.DOM_VK_SPACE:
+          case KeyEvent.DOM_VK_TAB:
+          case KeyEvent.DOM_VK_PAGE_UP:
+          case KeyEvent.DOM_VK_PAGE_DOWN:
+          case KeyEvent.DOM_VK_UP:
+          case KeyEvent.DOM_VK_DOWN:
+          case KeyEvent.DOM_VK_F:
+          case KeyEvent.DOM_VK_B:
+            break;
+          default:
+            return;
+        }
+      }
+      document.removeEventListener("scroll", markReadInView, true);
       clearTimeout(markReadInView.timeout);
       markReadInView.timeout = setTimeout(function () {
-        document.addEventListener("scroll", markReadInView, false);
+        document.addEventListener("scroll", markReadInView, true);
       }, 200);
       if (!Conversations.currentConversation)
         return;

--- a/modules/conversation.js
+++ b/modules/conversation.js
@@ -818,8 +818,8 @@ Conversation.prototype = {
 
       let w = this._htmlPane.contentWindow;
       w.clearTimeout(w.markReadInView.timeout);
-      [w.document.removeEventListener(x, w.markReadInView, false)
-        for each ([, x] in Iterator(["mouseover", "focus", "scroll"]))];
+      [w.document.removeEventListener(x, w.markReadInView, true)
+        for each ([, x] in Iterator(["mouseover", "focus", "keydown", "scroll"]))];
 
       $("#messageTemplate").tmpl(tmplData).appendTo($(this._domNode));
 
@@ -1165,8 +1165,8 @@ Conversation.prototype = {
       //  of notifying us that we should update the conversation buttons.
 
       let w = self._htmlPane.contentWindow;
-      [w.document.addEventListener(x, w.markReadInView, false)
-        for each ([, x] in Iterator(["mouseover", "focus"]))];
+      [w.document.addEventListener(x, w.markReadInView, true)
+        for each ([, x] in Iterator(["mouseover", "focus", "keydown"]))];
     }, this.messages.length);
 
     for each (let [i, action] in Iterator(expandThese)) {


### PR DESCRIPTION
I changed to useCapture: true, because keydown event does't occur in some cases If useCapture: false.
I narrow the range of keys for reducing overhead.
