### PR TITLE
Fix script error when running without Enigmail installed

### DIFF
--- a/modules/plugins/enigmail.js
+++ b/modules/plugins/enigmail.js
@@ -599,7 +599,8 @@ let enigmailHook = {
   // For the case when the message which has been already streamed is
   // selected at message list.
   onFocusMessage: function _enigmailHook_onFocusMessage(aMessage) {
-    updateSecurityInfo(aMessage);
+    if (hasEnigmail)
+      updateSecurityInfo(aMessage);
   },
 }
 


### PR DESCRIPTION
I added forgotten `if (hasEnigmail)`. Is this right?

```
updateSecurityInfo([object Object])@resource://conversations/plugins/enigmail.js:340
_enigmailHook_onFocusMessage([object Object])@resource://conversations/plugins/enigmail.js:602
()@resource://conversations/conversation.js:1154
_Conversation_signal()@resource://conversations/conversation.js:107
_Message_signal()@resource://conversations/message.js:1134
f_temp1([object Event])@resource://conversations/message.js:1314
```
