### PR TITLE
Hide vertical scrollbar in messages.

### DIFF
--- a/modules/message.js
+++ b/modules/message.js
@@ -1258,7 +1258,7 @@ Message.prototype = {
 
     let iframe = this._domNode.ownerDocument
       .createElementNS("http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul", "iframe");
-    iframe.setAttribute("style", "height: 20px");
+    iframe.setAttribute("style", "height: 20px; overflow-y: hidden");
     iframe.setAttribute("type", "content");
 
     let delay = 100;


### PR DESCRIPTION
Some messages have meaningless vertical scroll bar when showing quoted text.
Here is a example on Windows XP with Thunderbird 11.0.
http://i.imgur.com/gJzsC.png

`iframe.style.height` seems 1 px shorter. This patch is workaround to hide scroll bar.
