### PR TITLE
message.js: don't steal tab-switching shortcuts

### DIFF
--- a/modules/message.js
+++ b/modules/message.js
@@ -255,7 +255,10 @@ KeyListener.prototype = {
         // Tag handling.
         // 0 removes all tags, 1 to 9 set the corresponding tag, if it exists
         if (event.which >= '0'.charCodeAt(0)
-            && event.which <= '9'.charCodeAt(0)) {
+            && event.which <= '9'.charCodeAt(0)
+            // Don't steal tab-switching shortcuts and friends.
+            && !event.altKey && !event.ctrlKey
+            && !event.shiftKey && !event.metaKey) {
           let i = event.which - '1'.charCodeAt(0);
           if (i == -1) {
             this.message.tags = [];


### PR DESCRIPTION
Previously, hitting Alt-1 through Alt-0 while the messages pane had
focus did not switch to that tab; it toggled the corresponding flag on
the current message. In stock Thunderbird, only unmodified 1 through 9
toggles flags, and only unmodified 0 clears them. So the fix here is to
ignore key events with modifiers set.

Fixes #572.
