### PR TITLE
Fix broken unicode characters in message subject in gallery view

### DIFF
--- a/content/gallery/js/gallery.js
+++ b/content/gallery/js/gallery.js
@@ -99,10 +99,15 @@ Gallery.prototype = {
       });
     }
 
+    function decode_utf8( s )
+    {
+      return decodeURIComponent( escape( s ) );
+    }
+
     // Output the data
     $("#imageTemplate").tmpl(data).appendTo($(".images"));
     // This will also update the tab title
-    document.title = strings.get("galleryTitle").replace("#1", this.subject);
+    document.title = strings.get("galleryTitle").replace("#1", decode_utf8(this.subject));
 
     $('a.lightBox').lightBox(); // Select all links that contains lightbox in the attribute rel
   },


### PR DESCRIPTION
In gallery view. In tab title some unicode characters from message subject were broken. For example "ó" in word znów was displayed inproperly. This small patch fixes this.
