### PR TITLE
Fix default cc/bcc reset on quick reply

### DIFF
--- a/content/stub.compose-ui.js
+++ b/content/stub.compose-ui.js
@@ -914,7 +914,7 @@ ComposeSession.prototype = {
   // Restore identity settings.
   restoreIdentity: function () {
     if (!this._doRestore)
-      retrun;
+      return;
     Log.debug("restoreIdentity: doCc: " + this._doCc + " doBcc: " + this._doBcc);
     this.params.identity.doCc = this._doCc;
     this.params.identity.doBcc = this._doBcc;


### PR DESCRIPTION
Fix for #626. This seems to work fine so far.

With default cc/bcc settings, default addresses are reset on quick reply
even if a user remove those manually. Disabling default cc/bcc settings
temporarily while sending will fix this issue.

With `popOut`, default cc/bcc is reset as before, since I don't know how
to call identity restore function just after opening compose window.
`MailServices.compose.OpenComposeWindowWithParams(null, params)`.

What do you think?
