### PR TITLE
Fix default cc/bcc reset on quick reply

### DIFF
--- a/content/stub.compose-ui.js
+++ b/content/stub.compose-ui.js
@@ -873,9 +873,7 @@ ComposeSession.prototype = {
     if (!popOut && (identity.doCc || identity.doBcc)) {
       // create new identity to avoid resetting default cc/bcc
       if (!self._fakeIdentity) {
-        let accountManager = Cc["@mozilla.org/messenger/account-manager;1"]
-                             .getService(Ci.nsIMsgAccountManager);
-        self._fakeIdentity = accountManager.createIdentity();
+        self._fakeIdentity = MailServices.accounts.createIdentity();
       }
       self._fakeIdentity.copy(identity);
       identity = self._fakeIdentity;


### PR DESCRIPTION
Updated patch of #628.
Your suggestion seems to work fine.

`nsMsgIdentity::Copy` will not copy `doCc` and `doBcc`.
http://hg.mozilla.org/comm-central/file/3f7c3f228397/mailnews/base/util/nsMsgIdentity.cpp#l567

With `popOut`, using new identity causes `from` field empty in new compose window.
It looks not good. So I didn't use new identity if `popOut`.
