### PR TITLE
Show warning and use PGP/MIME with attachments

### DIFF
--- a/content/stub.compose-ui.js
+++ b/content/stub.compose-ui.js
@@ -848,7 +848,7 @@ ComposeSession.prototype = {
                 to: to,
                 cc: cc,
                 bcc: bcc,
-              }, ed, sendStatus, popOut);
+              }, ed, sendStatus, popOut, self.attachmentList);
             if (priority != "_canceled")
               sendStatus = newSendStatus;
           }

--- a/locale/en-US/message.properties
+++ b/locale/en-US/message.properties
@@ -65,6 +65,7 @@ signed=signed
 encrypted=encrypted
 unknownGood=unknown good signature
 messageSendingCanceled=Sending the message was canceled.
+attachmentsNotEncrypted=Attachments will not be encrypted using inline-PGP.\nInstead send message using PGP/MIME?
 
 # This is for the bugzilla support. View a bugzilla thread an follow the
 # instructions to test this.

--- a/modules/hook.js
+++ b/modules/hook.js
@@ -28,12 +28,13 @@ var EXPORTED_SYMBOLS = ['registerHook', 'getHooks', 'removeHook'];
  *  // @param aStatus.canceled Sending the message is canceled.
  *  // @param aStatus.securityInfo An object for PGM/MIME message.
  *  // @param aPopout if set, message will not be opened in compose window
+ *  // @param aAttachmentList The AttachmentList object.
  *  // @return aStatus Same remark.
- *  onMessageBeforeSendOrPopout_early: function (aAddress, aEditor, aStatus, aPopout) {
+ *  onMessageBeforeSendOrPopout_early: function (aAddress, aEditor, aStatus, aPopout, aAttachmentList) {
  *  },
- *  onMessageBeforeSendOrPopout: function (aAddress, aEditor, aStatus, aPopout) {
+ *  onMessageBeforeSendOrPopout: function (aAddress, aEditor, aStatus, aPopout, aAttachmentList) {
  *  },
- *  onMessageBeforeSendOrPopout_canceled: function (aAddress, aEditor, aStatus, aPopout) {
+ *  onMessageBeforeSendOrPopout_canceled: function (aAddress, aEditor, aStatus, aPopout, aAttachmentList) {
  *  },
  *
  *  // Called when quick reply body is composed.


### PR DESCRIPTION
If we send a message with attachments using inline-PGP and quick reply,
attachments are not be encrypted. In the case we show warning message
and we can switch to PGP/MIME.

Fix for #640.

Thank you.
