### PR TITLE
Fix security info display for recent Enigmail

### DIFF
--- a/modules/plugins/enigmail.js
+++ b/modules/plugins/enigmail.js
@@ -617,8 +617,14 @@ let enigmailHook = {
 
   // Update security info when the message is selected.
   onMessageSelected: function _enigmailHook_onMessageSelected(aMessage) {
-    if (hasEnigmail)
+    if (hasEnigmail) {
+      // EnigmailVerify is supported since Enigmail 1.4.6
+      // lastMsgUri is used for security info display to get current message.
+      let w = topMail3Pane(aMessage);
+      if (w.EnigmailVerify)
+        w.EnigmailVerify.lastMsgUri = aMessage._uri;
       updateSecurityInfo(aMessage);
+    }
   },
 }
 


### PR DESCRIPTION
Hello,

I've fixed an issue for recent Enigmail change. Please take a look.

PGP/MIME decryption has been rewritten in Enigmail 1.4.6, which causes to
show wrong security info for selected message. Setting selected
message's uri on select fixes this issue.
