### PR TITLE
Fix an error to display pgp message with Enigmail 1.5.1

### DIFF
--- a/modules/plugins/enigmail.js
+++ b/modules/plugins/enigmail.js
@@ -404,7 +404,7 @@ let enigmailHook = {
       this._domNode = domNode;
       let w = topMail3Pane(aMessage);
       let hasEnc = (aMessage.contentType+"").search(/^multipart\/encrypted(;|$)/i) == 0;
-      if (hasEnc && !enigmailSvc.mimeInitialized()) {
+      if (hasEnc && enigmailSvc.mimeInitialized && !enigmailSvc.mimeInitialized()) {
         Log.debug("Initializing EnigMime");
         w.document.getElementById("messagepane").setAttribute("src", "enigmail:dummy");
       }


### PR DESCRIPTION
I've fixed one more bug with Enigmail 1.5.1. It's caused by Enigmail code change.

enigmailSvc.mimeInitialized() was removed.
http://sourceforge.net/p/enigmail/source/ci/0a50a6d763b46761e283fc01ba1dd766ab2ddd88
