### PR TITLE
Fix signed label click bugs of PGP signed messages

### DIFF
--- a/modules/plugins/enigmail.js
+++ b/modules/plugins/enigmail.js
@@ -394,8 +394,14 @@ function patchForShowSecurityInfo(aWindow) {
 
 // Add signed label and click action to a signed message.
 function addSignedLabel(aStatus, aDomNode, aMessage) {
-  if (aStatus & (Ci.nsIEnigmail.GOOD_SIGNATURE |
-      Ci.nsIEnigmail.UNVERIFIED_SIGNATURE)) {
+  if (aStatus & (Ci.nsIEnigmail.BAD_SIGNATURE |
+      Ci.nsIEnigmail.GOOD_SIGNATURE |
+      Ci.nsIEnigmail.EXPIRED_KEY_SIGNATURE |
+      Ci.nsIEnigmail.EXPIRED_SIGNATURE |
+      Ci.nsIEnigmail.UNVERIFIED_SIGNATURE |
+      Ci.nsIEnigmail.REVOKED_KEY |
+      Ci.nsIEnigmail.EXPIRED_KEY_SIGNATURE |
+      Ci.nsIEnigmail.EXPIRED_SIGNATURE)) {
     aDomNode.classList.add("signed");
     let w = getMail3Pane();
     let signedTag = aDomNode.querySelector(".keep-tag.tag-signed");


### PR DESCRIPTION
I fixed bugs when clicking signed label of PGP signed messages.
-  Fix that alert dialog shows twice when clicking sign label
-  Add missing status flags for PGP signed messages

Please review the patch.
