### PR TITLE
getSortStringForRow() passed a parameter as hdr, refers to it as msgHdr

### DIFF
--- a/modules/monkeypatch.js
+++ b/modules/monkeypatch.js
@@ -210,7 +210,7 @@ MonkeyPatch.prototype = {
         let msgHdr = window.gDBView.getMsgHdrAt(row);
         return participants(msgHdr);    
       },
-      getSortStringForRow: function(hdr) {
+      getSortStringForRow: function(msgHdr) {
         return participants(msgHdr);
       },
       isString: function() {


### PR DESCRIPTION
This throws an error normally, and seems to be at least partially responsible
for the conversation window getting wedged and never displaying a new message
in some cases.

At the very least this code was obviously wrong in some way.
