### PR TITLE
message.js: trying to set character set throws exception, prevents msg display

### DIFF
--- a/modules/message.js
+++ b/modules/message.js
@@ -1569,9 +1569,9 @@ Message.prototype = {
             +" You changed conversations very fast, and the streaming completed after the conversation"
             +" was blown away by the newer one.");
         }
-        cv.hintCharacterSet = "UTF-8";
-        cv.forceCharacterSet = "UTF-8";
-        cv.hintCharacterSetSource = kCharsetFromChannel;
+        //cv.hintCharacterSet = "UTF-8";
+        //cv.forceCharacterSet = "UTF-8";
+        //cv.hintCharacterSetSource = kCharsetFromChannel;
         /* Is this even remotely useful? */
         iframe.docShell.appType = Ci.nsIDocShell.APP_TYPE_MAIL;
 


### PR DESCRIPTION
Trying to force the character set to UTF-8 here throws a
NS_ERROR_XPC_CANT_MODIFY_PROP_ON_WN exception and prevents
the conversation window displaying at all in Thunderbird 31.0.

Commenting out these 3 lines fixes the problem.

This is more of a "this is a bug with a hacky solution" pull request, since I don't know what the wider ramifications of doing this are - but on my desktop I was having a lot of problems with conversations and particularly new messages never displaying. Activating debug mode pointed me at these 3 lines, and commenting them out has made everything work again.
