### PR TITLE
Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ these steps.
 4. Change into the main folder and run `./build.sh`.
 
 This will package an `.xpi` file of the latest codebase which can be installed via add-on manager in Thunderbird.
-Please note that the latest `GMail-conersation`-builds are only compatible with the `Daily`-version of Thunderbird. You can build this from source or get a pre-built binary at http://ftp.mozilla.org/pub/mozilla.org/thunderbird/nightly/latest-comm-central/.
+Please note that the latest `GMail-conversation`-builds are only compatible with the `Daily`-version of Thunderbird. You can build this from source or get a pre-built binary at http://ftp.mozilla.org/pub/mozilla.org/thunderbird/nightly/latest-comm-central/.
 
 TESTING
 =======


### PR DESCRIPTION
- Remove unnecessary version number
- Point out different commands for the 'nodejs' package
- Point out that Daily-version of Thunderbird is required for testing the add-on
- Remove redundant 'Hacking'-chapter

Regarding the last point: In my opinion all necessary points are made in the 'INSTALL'-chapter. Furthermore, it is said in 'Hacking' that 'make' should be called in the pdfjs-package. This is confusing as it should be 'node(js) make'
