### PR TITLE
Handle cycling with dir=-1 correctly

### DIFF
--- a/content/stub.compose-ui.js
+++ b/content/stub.compose-ui.js
@@ -480,7 +480,7 @@ ComposeSession.prototype = {
   cycleSender: function (dir) {
     let self = this;
     let index = getIdentities().findIndex(function (ident) ident.identity == self.params.identity);
-    index = (index + dir) % getIdentities().length;
+    index = (index + dir + getIdentities().length) % getIdentities().length;
     this.params.identity = getIdentities()[index].identity;
     this.senderNameElem.text(this.params.identity.email);
   },


### PR DESCRIPTION
Sorry, I overlooked this. At first I though the addition of the list's length was senseless because of the modulo, but later I had a brain wave what's the real reason for this ;-)

Btw: We call getIdentities() 4 times in this function. Do you think it's better to call just once and cache the result or it the overhead negligible?
