### PR TITLE
Allow option to open normal window w/ double click / enter

### DIFF
--- a/content/options.xul
+++ b/content/options.xul
@@ -38,15 +38,15 @@
    - ***** END LICENSE BLOCK ***** -->
 
 <!DOCTYPE window SYSTEM "chrome://conversations/locale/options.dtd">
- 
+
 <vbox xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
 
-  <setting pref="conversations.expand_who" type="radio" title="&option.expand_who;">  
-    <radiogroup>  
+  <setting pref="conversations.expand_who" type="radio" title="&option.expand_who;">
+    <radiogroup>
       <radio value="1" label="&option.expand_none;" />
       <radio value="3" label="&option.expand_all;" />
       <radio value="4" label="&option.expand_auto2;" tooltiptext="&option.expand_auto2.tooltip;"/>
-    </radiogroup>  
+    </radiogroup>
   </setting>
 
   <setting title="&title.quoting2;" desc="&desc.quoting;" pref="conversations.hide_quote_length" type="integer" />
@@ -69,13 +69,14 @@
     pref="mailnews.sendInBackground" type="bool" />
 
   <setting title="&title.operate_on_conversations;" desc="&option.operate_on_conversations;" pref="conversations.operate_on_conversations" type="bool" />
-  <setting title="&title.assistant;" type="control">  
+  <setting title="&title.assistant;" type="control">
     <button label="&option.assistant;"
       oncommand="window.openDialog('chrome://conversations/content/assistant/assistant.xhtml', '', 'chrome,width=800,height=500');"
      />
   </setting>
   <setting title="&title.extra_attachments;" desc="&desc.extra_attachments2;" pref="conversations.extra_attachments" type="bool" />
   <setting title="&title.compose_in_tab;" desc="&desc.compose_in_tab;" pref="conversations.compose_in_tab" type="bool" />
+  <setting title="&title.message_open_in_conversation;" desc="&desc.message_open_in_conversation;" pref="conversations.message_open_in_conversation" type="bool" />
   <setting title="&title.debugging;" desc="&desc.debugging;" pref="conversations.logging_enabled" type="bool" />
- 
+
 </vbox>

--- a/defaults/preferences/defaults.js
+++ b/defaults/preferences/defaults.js
@@ -14,3 +14,4 @@ pref("conversations.extra_attachments", false);
 pref("conversations.compose_in_tab", true);
 pref("conversations.unwanted_recipients", "{}");
 pref("conversations.hide_sigs", false);
+pref("conversations.message_open_in_conversation", true);

--- a/locale/en-US/options.dtd
+++ b/locale/en-US/options.dtd
@@ -23,6 +23,8 @@
 <!ENTITY option.tweak_chrome "Scale down the font size for the conversation chrome (recommended, requires restart).">
 <!ENTITY title.add_embeds "Add embeds">
 <!ENTITY option.add_embeds "Detect links to various services (e.g. YouTube) in emails, and view them inline.">
+<!ENTITY title.message_open_in_conversation "Double click/enter on message opens in conversation view">
+<!ENTITY desc.message_open_in_conversation "If unselected, clicking on a message will open the message in a new window in traditional view, as several windowing features are currently not available (requires restart)">
 <!ENTITY title.debugging "Debugging">
 <!ENTITY desc.debugging "Enable debug output in the system console and the error console. This will generate a lot of messages.">
 <!ENTITY title.operate_on_conversations "Toolbar buttons">

--- a/modules/monkeypatch.js
+++ b/modules/monkeypatch.js
@@ -399,29 +399,31 @@ MonkeyPatch.prototype = {
       return kStubUrl + queryString;
     };
 
-    // Below is the code that intercepts the double-click-on-a-message event,
-    //  and reroutes the control flow to our conversation reader.
-    let oldThreadPaneDoubleClick = window.ThreadPaneDoubleClick;
-    window.ThreadPaneDoubleClick = function () {
-      if (!Prefs.enabled)
-        return oldThreadPaneDoubleClick();
+    if (Prefs.message_open_in_conversation) {
+      // Below is the code that intercepts the double-click-on-a-message event,
+      //  and reroutes the control flow to our conversation reader.
+      let oldThreadPaneDoubleClick = window.ThreadPaneDoubleClick;
+      window.ThreadPaneDoubleClick = function () {
+        if (!Prefs.enabled)
+          return oldThreadPaneDoubleClick();
 
-      let tabmail = window.document.getElementById("tabmail");
-      // ThreadPaneDoubleClick calls OnMsgOpenSelectedMessages. We don't want to
-      // replace the whole ThreadPaneDoubleClick function, just the line that
-      // calls OnMsgOpenSelectedMessages in that function. So we do that weird
-      // thing here.
-      let oldMsgOpenSelectedMessages = window.MsgOpenSelectedMessages;
-      let msgHdrs = window.gFolderDisplay.selectedMessages;
-      if (!msgHdrs.some(msgHdrIsRss) && !msgHdrs.some(msgHdrIsNntp)) {
-        window.MsgOpenSelectedMessages = function () {
-          openConversationInTabOrWindow(mkConvUrl(msgHdrs));
-        };
-      }
-      oldThreadPaneDoubleClick();
-      window.MsgOpenSelectedMessages = oldMsgOpenSelectedMessages;
-    };
-    this.pushUndo(function() window.ThreadPaneDoubleClick = oldThreadPaneDoubleClick);
+        let tabmail = window.document.getElementById("tabmail");
+        // ThreadPaneDoubleClick calls OnMsgOpenSelectedMessages. We don't want to
+        // replace the whole ThreadPaneDoubleClick function, just the line that
+        // calls OnMsgOpenSelectedMessages in that function. So we do that weird
+        // thing here.
+        let oldMsgOpenSelectedMessages = window.MsgOpenSelectedMessages;
+        let msgHdrs = window.gFolderDisplay.selectedMessages;
+        if (!msgHdrs.some(msgHdrIsRss) && !msgHdrs.some(msgHdrIsNntp)) {
+          window.MsgOpenSelectedMessages = function () {
+            openConversationInTabOrWindow(mkConvUrl(msgHdrs));
+          };
+        }
+        oldThreadPaneDoubleClick();
+        window.MsgOpenSelectedMessages = oldMsgOpenSelectedMessages;
+      };
+      this.pushUndo(function() window.ThreadPaneDoubleClick = oldThreadPaneDoubleClick);
+    }
 
     // Same thing for middle-click
     let oldTreeOnMouseDown = window.TreeOnMouseDown;

--- a/modules/prefs.js
+++ b/modules/prefs.js
@@ -65,6 +65,7 @@ function PrefManager() {
   this.hide_quote_length = prefsService.getIntPref("hide_quote_length");
   this.hide_sigs = prefsService.getBoolPref("hide_sigs");
   this.compose_in_tab = prefsService.getBoolPref("compose_in_tab");
+  this.message_open_in_conversation = prefsService.getBoolPref("message_open_in_conversation");
   // This is a hashmap
   this.monospaced_senders = {};
   for (let s of this.split(prefsService.getCharPref("monospaced_senders")))


### PR DESCRIPTION
I'm guessing you aren't interested in this one as it is only a temporary workaround for #914 that I'm using locally.  The window that gets opened is really unusable, as not only do keyboard controls not work but you also don't get any contextual menu on hyperlinks or anything else.    This is at least a patch folks can try out if they have the same problem.
