### PR TITLE
Fix isEncrypted false of PGP encrypted message

### DIFF
--- a/modules/conversation.js
+++ b/modules/conversation.js
@@ -263,6 +263,7 @@ function messageFromGlodaIfOffline (aSelf, aGlodaMsg, aDebug) {
     !(aMsgHdr.folder instanceof Ci.nsIMsgLocalMailFolder) &&
       !(aMsgHdr.folder.flags & Ci.nsMsgFolderFlags.Offline) || // online IMAP
     aGlodaMsg.isEncrypted || // encrypted message
+    (aGlodaMsg.contentType + "").search(/^multipart\/encrypted(;|$)/i) == 0 || // encrypted message
     Prefs.extra_attachments; // user request
   return {
     type: kMsgGloda,

--- a/modules/message.js
+++ b/modules/message.js
@@ -1751,6 +1751,9 @@ function MessageFromGloda(aConversation, aGlodaMsg, aLateAttachments) {
   if ("isEncrypted" in aGlodaMsg)
     this.isEncrypted = aGlodaMsg.isEncrypted;
 
+  if ((aGlodaMsg.contentType + "").search(/^multipart\/encrypted(;|$)/i) == 0)
+    this.isEncrypted = true;
+
   if ("mailingLists" in aGlodaMsg)
     this.mailingLists =
       [x.value for (x of aGlodaMsg.mailingLists)];


### PR DESCRIPTION
PGP encrypted message is always `aGlodaMsg.isEncrypted == false`
for some reason.
As a workaround, we check content type.