### PR TITLE
Fix errors on quick reply with trunk

### DIFF
--- a/content/stub.completion-ui.js
+++ b/content/stub.completion-ui.js
@@ -2,6 +2,12 @@
 
 // ----- Autocomplete stuff. Understand it as a part of stub.compose-ui.js
 
+const Ci = Components.interfaces;
+const Cc = Components.classes;
+const Cu = Components.utils;
+const Cr = Components.results;
+
+Cu.import("resource:///modules/StringBundle.js"); // for StringBundle
 Cu.import("resource:///modules/errUtils.js");
 Cu.import("resource:///modules/gloda/gloda.js");
 Cu.import("resource:///modules/gloda/public.js");
@@ -10,6 +16,10 @@ Cu.import("resource:///modules/gloda/suffixtree.js");
 Cu.import("resource:///modules/gloda/noun_tag.js");
 Cu.import("resource:///modules/gloda/noun_freetag.js");
 Cu.import("resource://conversations/modules/stdlib/misc.js");
+Cu.import("resource://conversations/modules/log.js");
+
+let Log = setupLogging("Conversations.Stub.Completion");
+let strings = new StringBundle("chrome://conversations/locale/message.properties");
 
 try {
   Cu.import("resource://people/modules/people.js");
@@ -17,8 +27,6 @@ try {
   Log.debug("You don't have Contacts installed. Gloda will provide autocomplete.");
 }
 
-let Log = setupLogging("Conversations.Stub.Completion");
-let strings = new StringBundle("chrome://conversations/locale/message.properties");
 
 // Wrap the given parameters in an object that's compatible with the
 //  facebook-style autocomplete.

--- a/content/stub.compose-ui.js
+++ b/content/stub.compose-ui.js
@@ -36,11 +36,6 @@
 
 "use strict";
 
-const Ci = Components.interfaces;
-const Cc = Components.classes;
-const Cu = Components.utils;
-const Cr = Components.results;
-
 Cu.import("resource://gre/modules/Services.jsm");
 Cu.import("resource://gre/modules/XPCOMUtils.jsm"); // for generateQI
 Cu.import("resource:///modules/mailServices.js");
@@ -58,7 +53,7 @@ Cu.import("resource://conversations/modules/log.js");
 Cu.import("resource://conversations/modules/misc.js");
 Cu.import("resource://conversations/modules/hook.js");
 
-let Log = setupLogging("Conversations.Stub.Compose");
+Log = setupLogging("Conversations.Stub.Compose");
 
 Cu.import("resource://conversations/modules/stdlib/SimpleStorage.js");
 let ss = SimpleStorage.createIteratorStyle("conversations");

--- a/content/stub.xhtml
+++ b/content/stub.xhtml
@@ -29,11 +29,11 @@
   <script type="application/javascript;version=1.8"
     src="chrome://conversations/content/quickReply.js"></script>
   <script type="application/javascript;version=1.8"
+    src="chrome://conversations/content/stub.completion-ui.js"></script>
+  <script type="application/javascript;version=1.8"
     src="chrome://conversations/content/stub.compose-ui.js"></script>
   <script type="application/javascript;version=1.8"
     src="chrome://conversations/content/stub.compose-ui-bz.js"></script>
-  <script type="application/javascript;version=1.8"
-    src="chrome://conversations/content/stub.completion-ui.js"></script>
   <script type="application/javascript;version=1.8"
     src="chrome://conversations/content/handlebars-wrapper.js"></script>
   <script type="application/javascript;version=1.8"><![CDATA[


### PR DESCRIPTION
We change the order of declaration to fix redeclaration and
reference errors.
`asToken` in stub.completion-ui.js is referenced in
stub.compose-ui.js. So we change to include stub.completion-ui.js
first.

Top-level const/let is lexical scope on trunk.
https://bugzilla.mozilla.org/show_bug.cgi?id=1209777