### PR TITLE
Fix ReferenceError: gSMFields is not defined

### DIFF
--- a/modules/plugins/enigmail.js
+++ b/modules/plugins/enigmail.js
@@ -120,6 +120,7 @@ let enigmailSvc;
 let gMsgCompose = {
   compFields: {}
 };
+let gSMFields = {};
 let global = this;
 
 if (hasEnigmail) {


### PR DESCRIPTION
With Enigmail 1.9.1 a reference error is caused when composing quick reply.
We set dummy `gSMFields` to fix the reference error.

Error log:

```
2016-04-28 10:48:28     Conversations.Stub      WARN    Plugin returned an error: ReferenceError: gSMFields is not defined
2016-04-28 10:48:28     Conversations   DEBUG
Enigmail.msg.processFinalState@chrome://enigmail/content/enigmailMsgComposeOverlay.js:1431:1
_enigmailHook_onComposeSessionChanged@resource://conversations/modules/plugins/enigmail.js:904:5
ComposeSession.prototype.setupDone@chrome://conversations/content/stub.compose-ui.js:740:13
ComposeSession.prototype.setupAutocomplete/<.reply/showHideActions@chrome://conversations/content/stub.compose-ui.js:664:11
ComposeSession.prototype.changeComposeFields/<@chrome://conversations/content/stub.compose-ui.js:641:16
replyAllParams/finish@resource://conversations/modules/stdlib/compose.js:394:5
replyAllParams/<@resource://conversations/modules/stdlib/compose.js:408:5
msgHdrGetHeaders/fallback/<@resource://conversations/modules/stdlib/msgHdrUtils.js:396:7
MsgHdrToMimeMessage/wrapCallback/<@resource:///modules/gloda/mimemsg.js:209:9
CallbackStreamListener.prototype.onStopRequest@resource:///modules/gloda/mimemsg.js:100:9
```