### PR TITLE
allow to break author Email

### DIFF
--- a/skin/conversation.css
+++ b/skin/conversation.css
@@ -376,6 +376,8 @@ a img {
   color: #888a85;
   float: left;
   clear: left;
+  white-space: normal;
+  max-width: 100%;
 }
 
 .authorPicture {


### PR DESCRIPTION
I often need to copy the sender email address. This is an issue if it is long because the button is hidden behind the picture. This change will allow the line to break and make the button usable again.

![example](https://cloud.githubusercontent.com/assets/202576/15802993/168e9964-2ac8-11e6-9d0e-d1dc3ee742b0.png)

Note that I did only try this with 2.10.2 as I am stuck with thunderbird 38.
