### PR TITLE
replaced all references to the old name

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If you just want to start hacking, see
 to learn how to use a proxy file. If you want to package a release, follow
 these steps.
 
-1. Download the [zip archive](https://github.com/protz/GMail-Conversation-View/archive/master.zip) or clone the repository
+1. Download the [zip archive](https://github.com/protz/thunderbird-conversations/archive/master.zip) or clone the repository
 2. Change into the main folder, run `git submodule init` and `git submodule update`
 3. Change into the subfolder `content/pdfjs`, run `node make bundle`. Note that you need to have `nodejs` installed. On modern Debian-based distributions the command is `nodejs` instead of `node`.
 4. Change into the main folder and run `./build.sh`.

--- a/install.rdf
+++ b/install.rdf
@@ -24,7 +24,7 @@
     <em:creator>Jonathan Protzenko</em:creator>
     <em:optionsURL>chrome://conversations/content/options.xul</em:optionsURL>
     <em:optionsType>2</em:optionsType>
-    <em:homepageURL>http://github.com/protz/GMail-Conversation-View/wiki</em:homepageURL>
+    <em:homepageURL>http://github.com/protz/thunderbird-conversations/wiki</em:homepageURL>
     <em:bootstrap>true</em:bootstrap>
     <em:type>2</em:type>
 
@@ -34,7 +34,7 @@
         <em:name>Thunderbird Conversations</em:name>
         <em:description>Porta un visor de conversa cap al teu Thunderbird</em:description>
         <em:creator>Jonathan Protzenko</em:creator>
-        <em:homepageURL>http://github.com/protz/GMail-Conversation-View/wiki</em:homepageURL>
+        <em:homepageURL>http://github.com/protz/thunderbird-conversations/wiki</em:homepageURL>
         <em:translator>CatTranslations (versió en català)</em:translator>
       </Description>
     </em:localized>
@@ -45,7 +45,7 @@
         <em:name>Konverzace pro Thunderbird</em:name>
         <em:description>Přináší do Thunderbirdu zobrazení konverzací!</em:description>
         <em:creator>Jonathan Protzenko</em:creator>
-        <em:homepageURL>http://github.com/protz/GMail-Conversation-View</em:homepageURL>
+        <em:homepageURL>http://github.com/protz/thunderbird-conversations</em:homepageURL>
         <em:translator>Martin Lukeš</em:translator>
       </Description>
     </em:localized>
@@ -56,7 +56,7 @@
         <em:name>Thunderbird Conversations</em:name>
         <em:description>Bringer samtalevisning til Din Thunderbird!</em:description>
         <em:creator>Jonathan Protzenko</em:creator>
-        <em:homepageURL>http://github.com/protz/GMail-Conversation-View/wiki</em:homepageURL>
+        <em:homepageURL>http://github.com/protz/thunderbird-conversations/wiki</em:homepageURL>
         <em:translator>Glenn Dufke
 http://code-kungfu.com
 
@@ -71,7 +71,7 @@ Tak til Jørgen Rasmussen / MozillaDanmark for korrekturlæsning.</em:translator
         <em:description>Gruppiert Ihre Nachrichten (inklusive Ihrer gesendeten) in Konversationen, ähnlich wie Googlemail es tut.</em:description>
         <em:translator>Sebastian Kronenwerth</em:translator>
         <em:creator>Jonathan Protzenko</em:creator>
-        <em:homepageURL>http://github.com/protz/GMail-Conversation-View/wiki</em:homepageURL>
+        <em:homepageURL>http://github.com/protz/thunderbird-conversations/wiki</em:homepageURL>
       </Description>
     </em:localized>
 
@@ -82,7 +82,7 @@ Tak til Jørgen Rasmussen / MozillaDanmark for korrekturlæsning.</em:translator
         <em:description>Προσφέρει εμφάνιση μηνυμάτων σε μορφή συνομιλίας στον Thunderbird!.</em:description>
         <em:translator>Γιώργος Φιωτάκης</em:translator>
         <em:creator>Jonathan Protzenko</em:creator>
-        <em:homepageURL>http://github.com/protz/GMail-Conversation-View/wiki</em:homepageURL>
+        <em:homepageURL>http://github.com/protz/thunderbird-conversations/wiki</em:homepageURL>
       </Description>
     </em:localized>
 
@@ -94,7 +94,7 @@ Tak til Jørgen Rasmussen / MozillaDanmark for korrekturlæsning.</em:translator
         <em:description>Brings a conversation view to a Thunderbird near you!</em:description>
         <em:translator>Jonathan Protzenko</em:translator>
         <em:creator>Jonathan Protzenko</em:creator>
-        <em:homepageURL>http://github.com/protz/GMail-Conversation-View/wiki</em:homepageURL>
+        <em:homepageURL>http://github.com/protz/thunderbird-conversations/wiki</em:homepageURL>
       </Description>
     </em:localized>
 
@@ -105,7 +105,7 @@ Tak til Jørgen Rasmussen / MozillaDanmark for korrekturlæsning.</em:translator
         <em:description>Permite visualizar los mensajes en modo de conversación, de igual manera que en GMail</em:description>
         <em:translator>Proyecto Nave</em:translator>
         <em:creator>Jonathan Protzenko</em:creator>
-        <em:homepageURL>http://github.com/protz/GMail-Conversation-View/wiki</em:homepageURL>
+        <em:homepageURL>http://github.com/protz/thunderbird-conversations/wiki</em:homepageURL>
       </Description>
     </em:localized>
 
@@ -114,7 +114,7 @@ Tak til Jørgen Rasmussen / MozillaDanmark for korrekturlæsning.</em:translator
         <em:locale>eu-ES</em:locale>
         <em:name>Thunderbird Conversations</em:name>
         <em:creator>Jonathan Protzenko</em:creator>
-        <em:homepageURL>http://github.com/protz/GMail-Conversation-View/wiki</em:homepageURL>
+        <em:homepageURL>http://github.com/protz/thunderbird-conversations/wiki</em:homepageURL>
         <em:translator>Ander Elortondo (librezale.org)</em:translator>
       </Description>
     </em:localized>
@@ -126,7 +126,7 @@ Tak til Jørgen Rasmussen / MozillaDanmark for korrekturlæsning.</em:translator
         <em:description>Affiche vos emails sous la forme de "conversations" comme sur Gmail. Vos emails sont regroupés et s'affichent sous forme de résumés de fils de discussion.</em:description>
         <em:translator>Eric B</em:translator>
         <em:creator>Jonathan Protzenko</em:creator>
-        <em:homepageURL>http://github.com/protz/GMail-Conversation-View/wiki</em:homepageURL>
+        <em:homepageURL>http://github.com/protz/thunderbird-conversations/wiki</em:homepageURL>
       </Description>
     </em:localized>
 
@@ -137,7 +137,7 @@ Tak til Jørgen Rasmussen / MozillaDanmark for korrekturlæsning.</em:translator
         <em:description>כווץ את הודעות הדוא"ל בשיחות, כולל ההודעות שלך, בדומה לג'יימל.‏</em:description>
         <em:translator>Dotan Cohen</em:translator>
         <em:creator>Jonathan Protzenko</em:creator>
-        <em:homepageURL>http://github.com/protz/GMail-Conversation-View/wiki</em:homepageURL>
+        <em:homepageURL>http://github.com/protz/thunderbird-conversations/wiki</em:homepageURL>
       </Description>
     </em:localized>
 
@@ -148,7 +148,7 @@ Tak til Jørgen Rasmussen / MozillaDanmark for korrekturlæsning.</em:translator
         <em:description>Permette di visualizzare le e-mail sotto forma di conversazioni in modo analogo al sito web di Gmail</em:description>
         <em:translator>Luana Di Muzio - BabelZilla</em:translator>
         <em:creator>Jonathan Protzenko</em:creator>
-        <em:homepageURL>http://github.com/protz/GMail-Conversation-View/wiki</em:homepageURL>
+        <em:homepageURL>http://github.com/protz/thunderbird-conversations/wiki</em:homepageURL>
       </Description>
     </em:localized>
 
@@ -159,7 +159,7 @@ Tak til Jørgen Rasmussen / MozillaDanmark for korrekturlæsning.</em:translator
         <em:description>返信メールが一目でわかるスレッドビューをあなたの Thunderbirdに!</em:description>
         <em:translator>SATO Kentaro</em:translator>
         <em:creator>Jonathan Protzenko</em:creator>
-        <em:homepageURL>http://github.com/protz/GMail-Conversation-View/wiki</em:homepageURL>
+        <em:homepageURL>http://github.com/protz/thunderbird-conversations/wiki</em:homepageURL>
       </Description>
     </em:localized>
 
@@ -170,7 +170,7 @@ Tak til Jørgen Rasmussen / MozillaDanmark for korrekturlæsning.</em:translator
         <em:description>Rozszerzenie dodaje do Thunderbirda widok konwersacji.</em:description>
         <em:translator>Leszek(teo)Życzkowski</em:translator>
         <em:creator>Jonathan Protzenko</em:creator>
-        <em:homepageURL>http://github.com/protz/GMail-Conversation-View</em:homepageURL>
+        <em:homepageURL>http://github.com/protz/thunderbird-conversations</em:homepageURL>
       </Description>
     </em:localized>
 
@@ -180,7 +180,7 @@ Tak til Jørgen Rasmussen / MozillaDanmark for korrekturlæsning.</em:translator
         <em:name>Thunderbird Conversations</em:name>
         <em:description>Traz o modo de conversa para um Thunderbird perto de você!</em:description>
         <em:creator>Jonathan Protzenko</em:creator>
-        <em:homepageURL>http://github.com/protz/GMail-Conversation-View</em:homepageURL>
+        <em:homepageURL>http://github.com/protz/thunderbird-conversations</em:homepageURL>
         <em:translator>Marcelo Ghelman (ghelman.net), Mauro José da Silva</em:translator>
       </Description>
     </em:localized>
@@ -192,7 +192,7 @@ Tak til Jørgen Rasmussen / MozillaDanmark for korrekturlæsning.</em:translator
         <em:description>Группирует Ваши электронные письма в беседах, с Вашими собственными включенными сообщениями, так же как в GMail.</em:description>
         <em:translator>Sergey Podushkin and Gudo Alexander</em:translator>
         <em:creator>Джонатан Проценко</em:creator>
-        <em:homepageURL>http://github.com/protz/GMail-Conversation-View/wiki</em:homepageURL>
+        <em:homepageURL>http://github.com/protz/thunderbird-conversations/wiki</em:homepageURL>
       </Description>
     </em:localized>
 
@@ -203,7 +203,7 @@ Tak til Jørgen Rasmussen / MozillaDanmark for korrekturlæsning.</em:translator
         <em:description>Групише е-поруке у разговоре, укључујући и Ваше поруке, као што то чини Gmail.</em:description>
         <em:translator>Charmed94</em:translator>
         <em:creator>Jonathan Protzenko</em:creator>
-        <em:homepageURL>http://github.com/protz/GMail-Conversation-View/wiki</em:homepageURL>
+        <em:homepageURL>http://github.com/protz/thunderbird-conversations/wiki</em:homepageURL>
       </Description>
     </em:localized>
 
@@ -214,7 +214,7 @@ Tak til Jørgen Rasmussen / MozillaDanmark for korrekturlæsning.</em:translator
         <em:description>Visa dina e-brev som fullständiga trådar eller grupperade och med trådsammanfattningar, precis som hos Gmail.</em:description>
         <em:translator>Mikael Hiort af Ornäs</em:translator>
         <em:creator>Jonathan Protzenko</em:creator>
-        <em:homepageURL>http://github.com/protz/GMail-Conversation-View/wiki</em:homepageURL>
+        <em:homepageURL>http://github.com/protz/thunderbird-conversations/wiki</em:homepageURL>
       </Description>
     </em:localized>
 
@@ -225,7 +225,7 @@ Tak til Jørgen Rasmussen / MozillaDanmark for korrekturlæsning.</em:translator
         <em:description>按邮件话题集中显示相关邮件（包括你自己发出的邮件）, 同Gmail目前的邮件显示方式一致</em:description>
         <em:translator>Wellown</em:translator>
         <em:creator>夏若朗 (Jonathan Protzenko)</em:creator>
-        <em:homepageURL>http://github.com/protz/GMail-Conversation-View/wiki</em:homepageURL>
+        <em:homepageURL>http://github.com/protz/thunderbird-conversations/wiki</em:homepageURL>
       </Description>
     </em:localized>
 

--- a/modules/message.js
+++ b/modules/message.js
@@ -2052,7 +2052,7 @@ let PostStreamingFixesMixIn = {
       return false;
     };
 
-    // https://github.com/protz/GMail-Conversation-View/issues#issue/179
+    // https://github.com/protz/thunderbird-conversations/issues#issue/179
     // See link above for a rationale ^^
     if (self.initialPosition > 0)
       self.detectBlocks(iframe,

--- a/other/oembed-addon/install.rdf
+++ b/other/oembed-addon/install.rdf
@@ -22,7 +22,7 @@
     <em:name>Flickr OEmbed support for Conversations</em:name>
     <em:description>Displays links to Flickr images like regular attachments</em:description>
     <em:creator>Jonathan Protzenko</em:creator>
-    <em:homepageURL>http://github.com/protz/GMail-Conversation-View/wiki</em:homepageURL>
+    <em:homepageURL>http://github.com/protz/thunderbird-conversations/wiki</em:homepageURL>
     <em:bootstrap>true</em:bootstrap>
   </Description>      
 


### PR DESCRIPTION
replaced all `GMail-Conversation-View` strings by `thunderbird-conversations`

- helps to avoid confusion in addon detail view
- links don't need redirect anmyore