### PR TITLE
Layout enhancements of email authors and recipients tooltip

### DIFF
--- a/content/stub.xhtml
+++ b/content/stub.xhtml
@@ -1123,17 +1123,19 @@
     class="tooltip">
       <div class="arrow"></div>
       <div class="arrow inside"></div>
-      <div class="authorInfo">
-        <span class="name">{{tooltipName}}</span>
-        <span class="authorEmail">
-          {{email}}
-          <button class="copyEmail" title="{{str 'copyEmail'}}">
-            <img src="chrome://conversations/content/i/clipboard.png" />
-          </button>
-        </span>
-      </div>
-      <div class="authorPicture">
-        <img src="{{avatar}}" />
+      <div class="authorInfoContainer">
+        <div class="authorInfo">
+          <span class="name" title="{{tooltipName}}">{{tooltipName}}</span>
+          <span class="authorEmail">
+            <span class="authorEmailAddress" title="{{email}}">{{email}}</span>
+            <button class="copyEmail" title="{{str 'copyEmail'}}">
+              <img src="chrome://conversations/content/i/clipboard.png" />
+            </button>
+          </span>
+        </div>
+        <div class="authorPicture">
+          <img src="{{avatar}}" />
+        </div>
       </div>
       <div class="tipFooter hiddenFooter" style="display:none;">
         {{#if showMonospace}}

--- a/skin/conversation.css
+++ b/skin/conversation.css
@@ -247,8 +247,8 @@ button {
 
 .tooltip {
   position: absolute;
-  width: 30.2rem;
-  min-width: 302px;
+  min-width: 30.2rem;
+  max-width: 45rem;
   top: 24px;
   left: 16px;
   background-color: -moz-field;
@@ -348,13 +348,16 @@ button {
   display: none;
 }
 
+.authorInfoContainer {
+  display: flex;
+  justify-content: space-between;
+}
+
 .authorInfo {
-  display: inline-block;
   font-weight: normal;
   font-size: 1.2rem;
   text-indent: 0;
-  float: left;
-  width: 20.0rem;
+  min-width: 20.0rem;
   padding: 10px;
 }
 
@@ -370,19 +373,26 @@ a img {
   font-size: 1.4rem;
   float: left;
   clear: left;
+  max-width: calc(40rem - 100px);
+  text-overflow: ellipsis;
+  overflow: hidden;
 }
 
 .authorEmail {
+  display: flex;
+  width: 100%;
   color: #888a85;
-  float: left;
-  clear: left;
-  white-space: normal;
-  max-width: 100%;
+  overflow: hidden;
+  padding-top: 3px;
+}
+
+.authorEmailAddress {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  margin-right: 5px;
 }
 
 .authorPicture {
-  display: inline-block;
-  float: right;
   max-width: 100px;
   padding: 10px;
 }


### PR DESCRIPTION
This fixes overflowing of email author's name and address, see screenshots what happens when they are too wide (overflow ellipsis). The button to copy the email address is always visible now, too, and not hidden by the picture.

![bildschirmfoto 2017-01-01 um 16 26 42](https://cloud.githubusercontent.com/assets/148003/21581775/fe507598-d03f-11e6-9110-01eeeebc6b7e.png)

![bildschirmfoto 2017-01-01 um 16 26 23](https://cloud.githubusercontent.com/assets/148003/21581777/005a8b9e-d040-11e6-8dac-19669fc979a9.png)
