### PR TITLE
use nativehyperlinktext color

### DIFF
--- a/skin/conversation.css
+++ b/skin/conversation.css
@@ -87,7 +87,7 @@ a img {
 
 .link {
   text-decoration: none;
-  color: -moz-HyperlinkText;
+  color: -moz-nativehyperlinktext;
   cursor: pointer;
 }
 

--- a/skin/quickreply.css
+++ b/skin/quickreply.css
@@ -8,7 +8,7 @@
 
 .quickReply a {
   text-decoration: none;
-  color: -moz-HyperlinkText;
+  color: -moz-nativehyperlinktext;
 }
 
 .quickReply {
@@ -80,7 +80,7 @@
   margin-top: -16px;
   line-height: 32px;
   text-align: center;
-  color: -moz-HyperlinkText;
+  color: -moz-nativehyperlinktext;
   white-space: nowrap;
   overflow: hidden;
 }


### PR DESCRIPTION
As mentioned in https://github.com/protz/thunderbird-conversations/issues/967#issuecomment-272686468, there is a problem with link colors if the chrome and composition colors are significantly different. This change might be a way to fix that: For the chrome, use `-moz-nativehyperlinktext` instead of `-moz-HyperlinkText`. 

Note that the value for `-moz-HyperlinkText` can be controlled from the UI (Preferences -> Display -> Formatting -> Colors). The matching background color is however not exposed to CSS (As far as I know).

I am not completely sure if this is a good idea. It should be tested with some different setups.