### PR TITLE
Reintroduce between column

### DIFF
--- a/modules/assistant.js
+++ b/modules/assistant.js
@@ -199,7 +199,7 @@ let Customizations = {
       let moveOn = function () {
         let tabmail = mainWindow.document.getElementById("tabmail");
         tabmail.switchToTab(0);
-        //mainWindow.MsgSortThreaded();
+        mainWindow.MsgSortThreaded();
         /**
          * We don't know how to revert these, so forget about it for now.
          */

--- a/modules/assistant.js
+++ b/modules/assistant.js
@@ -167,6 +167,7 @@ let Customizations = {
         ftvMode: null,
         unreadCol: null,
         senderCol: null,
+        correspondentCol: null,
         initialFolder: {
           uri: null,
           show: null,
@@ -208,8 +209,11 @@ let Customizations = {
         mainWindow.goDoCommand('cmd_collapseAllThreads');
         state.unreadCol = eid("unreadCol").getAttribute("hidden");
         state.senderCol = eid("senderCol").getAttribute("hidden");
+        state.correspondentCol = eid("correspondentCol").getAttribute("hidden");
         eid("unreadCol").setAttribute("hidden", "false");
         eid("senderCol").setAttribute("hidden", "true");
+        eid("correspondentCol").setAttribute("hidden", "true");
+        eid("betweenCol").setAttribute("hidden", "false");
         Customizations.ttop();
       };
       let i = 0;
@@ -229,8 +233,10 @@ let Customizations = {
     uninstall: function ({ ftvMode, senderCol, unreadCol, initialFolder }) {
       if (eid("senderCol").getAttribute("hidden") == "true")
         eid("senderCol").setAttribute("hidden", senderCol);
-      if (eid("unreadCol").getAttribute("hidden") == "false")
+      if (eid("unreadCol").getAttribute("hidden") == "true")
         eid("unreadCol").setAttribute("hidden", unreadCol);
+      if (eid("correspondentCol").getAttribute("hidden") == "true")
+        eid("correspondentCol").setAttribute("hidden", correspondentCol);
       let mainWindow = getMail3Pane();
       mainWindow.gFolderTreeView.mode = ftvMode;
 

--- a/modules/monkeypatch.js
+++ b/modules/monkeypatch.js
@@ -124,6 +124,26 @@ MonkeyPatch.prototype = {
     let parent2 = window.document.getElementById("mailKeys");
     parent2.appendChild(key);
     this.pushUndo(() => parent2.removeChild(key));
+
+    // 4) Tree column
+    let treecol = window.document.createElement("treecol");
+    [
+      ["id", "betweenCol"],
+      ["hidden", "false"],
+      ["flex", "4"],
+      ["persist", "width hidden ordinal"],
+      ["label", strings.get("betweenColumnName")],
+      ["tooltiptext", strings.get("betweenColumnTooltip")]
+    ].forEach(function([k, v]) {
+      treecol.setAttribute(k, v);
+    });
+    let parent3 = window.document.getElementById("threadCols");
+    parent3.appendChild(treecol);
+    this.pushUndo(() => parent3.removeChild(treecol));
+    let splitter = window.document.createElement("splitter");
+    splitter.classList.add("tree-splitter");
+    parent3.appendChild(splitter);
+    this.pushUndo(() => parent3.removeChild(splitter));
   },
 
 

--- a/modules/monkeypatch.js
+++ b/modules/monkeypatch.js
@@ -147,6 +147,113 @@ MonkeyPatch.prototype = {
   },
 
 
+  registerColumn: function _MonkeyPatch_registerColumn () {
+    // This has to be the first time that the documentation on MDC
+    //  1) exists and
+    //  2) is actually relevant!
+    //
+    //            OMG !
+    //
+    // https://developer.mozilla.org/en/Extensions/Thunderbird/Creating_a_Custom_Column
+    let window = this._window;
+
+    let participants = function (msgHdr) {
+      try {
+        // The array of people involved in this email.
+        let people = [];
+        // Helper for formatting; depending on the locale, we may need a different
+        // for me as in "to me" or as in "from me".
+        let format = function (x, p) {
+          if (getIdentityForEmail(x.email)) {
+            let display = (p
+              ? strings.get("meBetweenMeAndSomeone")
+              : strings.get("meBetweenSomeoneAndMe")
+            );
+            if (getIdentities().length > 1)
+              display += " (" + x.email + ")";
+            return display;
+          }
+          else
+            return x.name || x.email;
+        };
+        // Add all the people found in one of the msgHdr's properties.
+        let addPeople = function (prop, pos) {
+          let line = msgHdr[prop];
+          parseMimeLine(line, true).forEach(function(x) {
+            people.push(format(x, pos))
+          });
+        }
+        // We add everyone
+        addPeople("author", true);
+        addPeople("recipients", false);
+        addPeople("ccList", false);
+        addPeople("bccList", false);
+        // Then remove duplicates
+        let seenAlready = {};
+        people = people.filter(function (x) {
+          let r = !(x in seenAlready);
+          seenAlready[x] = true;
+          return r;
+        });
+        // And turn this into a human-readable line.
+        if (people.length)
+          return joinWordList(people);
+        else
+          return "-";
+      } catch (e) {
+        Log.debug("Error in the special column", e);
+        dumpCallStack(e);
+      }
+    };
+
+    let columnHandler = {
+      getCellText: function(row, col) {
+        let msgHdr = window.gDBView.getMsgHdrAt(row);
+        return participants(msgHdr);
+      },
+      getSortStringForRow: function(msgHdr) {
+        return participants(msgHdr);
+      },
+      isString: function() {
+        return true;
+      },
+      getCellProperties: function(row, col, props) {},
+      getRowProperties: function(row, props) {},
+      getImageSrc: function(row, col) {
+        return null;
+      },
+      getSortLongForRow: function(hdr) {
+        return 0;
+      }
+    };
+
+    // The main window is loaded when the monkey-patch is applied
+    Services.obs.addObserver({
+      observe: function(aMsgFolder, aTopic, aData) {
+        window.gDBView.addColumnHandler("betweenCol", columnHandler);
+      }
+    }, "MsgCreateDBView", false);
+    try {
+      window.gDBView.addColumnHandler("betweenCol", columnHandler);
+    } catch (e) {
+      // This is really weird, but rkent does it for junquilla, and this solves
+      //  the issue of enigmail breaking us... don't wanna know why it works,
+      //  but it works.
+      // After investigating, it turns out that without enigmail, we have the
+      //  following sequence of events:
+      // - jsm load
+      // - onload
+      // - msgcreatedbview
+      // With enigmail, this sequence is modified
+      // - jsm load
+      // - msgcreatedbview
+      // - onlaod
+      // So our solution kinda works, but registering the thing at jsm load-time
+      //  would work as well.
+    }
+    this.pushUndo(function () window.gDBView.removeColumnHandler("betweenCol"));
+  },
+
   registerFontPrefObserver: function _MonkeyPatch_registerFontPref (aHtmlpane) {
     let prefBranch = Cc["@mozilla.org/preferences-service;1"]
       .getService(Ci.nsIPrefService)
@@ -275,6 +382,8 @@ MonkeyPatch.prototype = {
     let oldSummarizeMultipleSelection = window["summarizeMultipleSelection"];
     let oldSummarizeThread = window["summarizeThread"];
 
+    // Register our new column type
+    this.registerColumn();
     this.registerFontPrefObserver(htmlpane);
 
     this.activateMenuItem(window);

--- a/modules/monkeypatch.js
+++ b/modules/monkeypatch.js
@@ -247,7 +247,7 @@ MonkeyPatch.prototype = {
       // With enigmail, this sequence is modified
       // - jsm load
       // - msgcreatedbview
-      // - onlaod
+      // - onload
       // So our solution kinda works, but registering the thing at jsm load-time
       //  would work as well.
     }


### PR DESCRIPTION
This should reintroduce the 'between'-column, which is indeed better than the correspondents-column btw.

Incidentally, I updated stdlib