### PR TITLE
Update footer styling

### DIFF
--- a/content/quickReply.js
+++ b/content/quickReply.js
@@ -95,20 +95,6 @@ function hideQuickReply() {
 
 function registerQuickReplyEventListeners() {
 
-  $('.popout').click(function (event) {
-    let $parent = $(this).parent();
-    let isSelected = $parent.hasClass("selected");
-    let type;
-    if ($parent.hasClass("reply"))
-      type = "reply";
-    else if ($parent.hasClass("replyAll"))
-      type = "replyAll";
-    else
-      Log.assert(false, "There's only two type of textareas");
-    onPopOut(event, type, isSelected);
-    event.stopPropagation();
-  });
-
   $('ul.inputs li.expand').click(function(event) {
     if ($(this).hasClass("selected"))
       return;

--- a/content/quickReply.js
+++ b/content/quickReply.js
@@ -56,6 +56,7 @@ function showQuickReply() {
   $(this).parent().addClass('noPad');
   $(this).addClass('selected');
   $(this).siblings().addClass('invisible');
+  $(this).closest('.messageFooter').find('.footerActions').hide();
   if (isQuickCompose)
     $('.replyHeader, .replyFooter').show();
   else
@@ -79,6 +80,7 @@ function hideQuickReply() {
     $('ul.inputs').removeClass('noPad');
     $('ul.inputs li').removeClass('selected');
     $('ul.inputs li').removeClass('invisible');
+    $('.quickReply').closest('.messageFooter').find('.footerActions').show();
 
     var textarea = $('.textarea.selected');
     makeEditable(textarea.get(0), false);

--- a/content/stub.compose-ui.js
+++ b/content/stub.compose-ui.js
@@ -148,18 +148,6 @@ function registerQuickReply() {
     onSave();
   });
 
-  // Register Forward and Reply to list
-  document.querySelector(".quickReply .fwd > a").addEventListener("click", function (event) {
-    getMessageForQuickReply().forward(event);
-    event.stopPropagation();
-    event.preventDefault();
-  }, false);
-  document.querySelector(".quickReply .list > a").addEventListener("click", function (event) {
-    getMessageForQuickReply().compose(Ci.nsIMsgCompType.ReplyToList, event)
-    event.stopPropagation();
-    event.preventDefault();
-  }, false);
-
   // Will set the placeholder and return the bz params
   gBzSetup = bzSetup();
   registerQuickReplyEventListeners();

--- a/content/stub.xhtml
+++ b/content/stub.xhtml
@@ -1091,10 +1091,10 @@
           <button class="buttonReplyList" title="{{str 'replyList'}}"><svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="chrome://conversations/skin/material-icons.svg#list"></use></svg></button>
           <button class="buttonForward" title="{{str 'forward'}}"><svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="chrome://conversations/skin/material-icons.svg#forward"></use></svg></button>
         </div>
+        {{#if quickReply}}
+          {{tmpl "quickReply" this}}
+        {{/if}}
       </div>
-      {{#if quickReply}}
-        {{tmpl "quickReply" this}}
-      {{/if}}
     </li>
     ]]>
   </script>
@@ -1324,7 +1324,7 @@
           </div>
         </div>
 
-        <ul class="inputs cf" style="padding-right: {{str 'actionsSize'}}rem">
+        <ul class="inputs cf">
           <li class="reply expand" ondragenter="quickReplyDragEnter(event);">
             <div class="popout" title="{{str 'popoutReply'}}" alt="popout">
               <span class="popoutTxt">{{str 'popoutTxt'}}</span>
@@ -1343,13 +1343,6 @@
               <div class="quickReplyIcon"><span>{{str "replyAll"}}</span> <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="chrome://conversations/skin/material-icons.svg#reply_all"></use></svg></div>
               <iframe mozframetype="content" class="textarea sans"></iframe>
             </div>
-          </li>
-
-          <li class="misc" style="width: {{str 'actionsSize'}}rem">
-            <ul class="actions cf">
-              <li class="fwd"><a href="javascript:"><svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="chrome://conversations/skin/material-icons.svg#forward"></use></svg> {{strC 'forward'}}</a></li>
-              <li class="list"><a href="javascript:"><svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="chrome://conversations/skin/material-icons.svg#list"></use></svg> {{strC 'replyList'}}</a></li>
-            </ul>
           </li>
         </ul>
 

--- a/content/stub.xhtml
+++ b/content/stub.xhtml
@@ -1087,10 +1087,10 @@
           <button class="buttonReplyList" title="{{str 'replyList'}}"><svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="chrome://conversations/skin/material-icons.svg#list"></use></svg></button>
           <button class="buttonForward" title="{{str 'forward'}}"><svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="chrome://conversations/skin/material-icons.svg#forward"></use></svg></button>
         </div>
-        {{#if quickReply}}
-          {{tmpl "quickReply" this}}
-        {{/if}}
       </div>
+      {{#if quickReply}}
+        {{tmpl "quickReply" this}}
+      {{/if}}
     </li>
     ]]>
   </script>

--- a/content/stub.xhtml
+++ b/content/stub.xhtml
@@ -585,10 +585,6 @@
         }
       }, false);
 
-      document.querySelector(".popout").addEventListener("click", function (event) {
-        onUseEditor();
-      }, false);
-
 
       let data = [];
 
@@ -1326,9 +1322,6 @@
 
         <ul class="inputs">
           <li class="reply expand" ondragenter="quickReplyDragEnter(event);">
-            <div class="popout" title="{{str 'popoutReply'}}" alt="popout">
-              <span class="popoutTxt">{{str 'popoutTxt'}}</span>
-            </div>
             <div class="textWrap">
               <div class="quickReplyIcon"><span>{{str "reply"}}</span> <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="chrome://conversations/skin/material-icons.svg#reply"></use></svg></div>
               <iframe mozframetype="content" class="textarea sans"></iframe>
@@ -1336,9 +1329,6 @@
           </li>
 
           <li class="replyAll expand" ondragenter="quickReplyDragEnter(event);">
-            <div class="popout" title="{{str 'popoutReplyAll'}}" alt="popout">
-              <span class="popoutTxt">{{str 'popoutTxt'}}</span>
-            </div>
             <div class="textWrap">
               <div class="quickReplyIcon"><span>{{str "replyAll"}}</span> <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="chrome://conversations/skin/material-icons.svg#reply_all"></use></svg></div>
               <iframe mozframetype="content" class="textarea sans"></iframe>

--- a/content/stub.xhtml
+++ b/content/stub.xhtml
@@ -1395,11 +1395,9 @@
     </ul>
     <div class="bottom-links">
       <a class="link" href="javascript:" onclick="forwardConversation(event);">
-        &stub.forward.tooltip;
-      </a> –
+        &stub.forward.tooltip;</a> –
       <a class="link" href="javascript:" onclick="printConversation(event);">
-        &stub.print.tooltip;
-      </a>
+        &stub.print.tooltip;</a>
     </div>
   </div>
 </body>

--- a/content/stub.xhtml
+++ b/content/stub.xhtml
@@ -1324,7 +1324,7 @@
           </div>
         </div>
 
-        <ul class="inputs cf">
+        <ul class="inputs">
           <li class="reply expand" ondragenter="quickReplyDragEnter(event);">
             <div class="popout" title="{{str 'popoutReply'}}" alt="popout">
               <span class="popoutTxt">{{str 'popoutTxt'}}</span>

--- a/locale/en-US/template.properties
+++ b/locale/en-US/template.properties
@@ -63,10 +63,6 @@ send=send
 sendArchive=send &amp; archive
 save=save
 discard=discard
-popoutReply=Reply in a new window
-popoutReplyAll=Reply all in a new window
-# That one has to be short for aesthetic reasons
-popoutTxt=in a new window
 
 # The right part of the new quick reply area (containing the "Forward" and
 # "Reply to list" text) might be too narrow to hold the text in your locale. In

--- a/skin/conversation.css
+++ b/skin/conversation.css
@@ -703,7 +703,7 @@ span.downwardArrow {
 /* bottom links: forward this conversation, print this conversation */
 .bottom-links {
   text-align: right;
-  padding: 0 15px 10px 10px;
+  padding: 5px 10px 10px 10px;
 }
 
 /* for printing */

--- a/skin/conversation.css
+++ b/skin/conversation.css
@@ -659,7 +659,7 @@ span.downwardArrow {
 }
 
 .footerActions button {
-  font-size: 150%;
+  font-size: 120%;
   background: none;
   border: 0;
   color: #666;

--- a/skin/conversation.css
+++ b/skin/conversation.css
@@ -449,7 +449,7 @@ span.downwardArrow {
 }
 
 .message .messageBody {
-  padding: 0 10px 5px;
+  padding: 0 10px;
 }
 
 .message.with-details .messageBody {
@@ -458,6 +458,7 @@ span.downwardArrow {
 
 .message iframe {
   width: 100%;
+  vertical-align: bottom;
 }
 
 .tags {
@@ -649,9 +650,7 @@ span.downwardArrow {
 }
 
 .messageFooter {
-  padding: 5px 10px;
-  background-color: rgba(160, 160, 160, 0.1);
-  border-top: 1px solid ThreeDShadow;
+  padding: 2px 10px;
 }
 
 .footerActions {

--- a/skin/conversation.css
+++ b/skin/conversation.css
@@ -449,7 +449,7 @@ span.downwardArrow {
 }
 
 .message .messageBody {
-  padding: 0 10px 5px 10px;
+  padding: 0 10px 5px;
 }
 
 .message.with-details .messageBody {
@@ -649,36 +649,30 @@ span.downwardArrow {
 }
 
 .messageFooter {
-  padding: 0 10px 5px 10px;
+  padding: 5px 10px;
   background-color: rgba(160, 160, 160, 0.1);
   border-top: 1px solid ThreeDShadow;
 }
 
+.footerActions {
+  float: right;
+}
+
 .messageFooter button {
-  background-image: none;
-  background-color: -moz-default-background-color;
+  font-size: 150%;
+  background: none;
+  border: 0;
   color: #666;
-
   float: left;
-  border: 1px solid ThreeDShadow;
-  border-top-color: -moz-default-background-color;
-
-  margin: -1px 3px 0 0;
-  padding: 0 5px 3px;
-
+  width: 2em;
+  height: 2em;
+  border-radius: 1em;
   cursor: pointer;
 }
 
 .messageFooter button:hover,
 .messageFooter button:focus {
-  border-color: #888a85;
-  border-top-color: -moz-default-background-color;
-}
-
-.messageFooter button:active {
-  background-image: none;
-  background-color: -moz-default-background-color;
-  box-shadow: none;
+  color: -moz-CellHighlight;
 }
 
 .messageFooter.hide .footerActions {

--- a/skin/conversation.css
+++ b/skin/conversation.css
@@ -658,20 +658,19 @@ span.downwardArrow {
   float: right;
 }
 
-.messageFooter button {
+.footerActions button {
   font-size: 150%;
   background: none;
   border: 0;
   color: #666;
-  float: left;
   width: 2em;
   height: 2em;
   border-radius: 1em;
   cursor: pointer;
 }
 
-.messageFooter button:hover,
-.messageFooter button:focus {
+.footerActions button:hover,
+.footerActions button:focus {
   color: -moz-CellHighlight;
 }
 

--- a/skin/quickreply.css
+++ b/skin/quickreply.css
@@ -15,19 +15,22 @@
 
 .quickReply ul.inputs {
   list-style-type: none;
-  overflow: hidden;
+  display: flex;
   transition: all 0.4s ease;
 }
 
 .quickReply ul.inputs li {
-  float: left;
   width: 50%;
-
   transition: all 0.4s ease;
+}
+
+.quickReply ul.inputs li:last-child {
+  margin-left: 10px;
 }
 
 .quickReply ul.inputs li.selected {
   width: 100%;
+  margin-left: 0;
 }
 
 .quickReply ul.inputs li.invisible {
@@ -36,7 +39,7 @@
 }
 
 .quickReply .textWrap {
-  margin: 5px 10px 10px 0;
+  margin: 5px 0 10px;
   background-color: Window;
   color: WindowText;
   position: relative;

--- a/skin/quickreply.css
+++ b/skin/quickreply.css
@@ -9,7 +9,7 @@
   font-size: 1.2rem;
   background-color: rgba(160, 160, 160, 0.1);
   border-top: 1px solid ThreeDShadow;
-  padding: 10px 10px;
+  padding: 10px;
   position: relative;
 }
 
@@ -39,7 +39,6 @@
 }
 
 .quickReply .textWrap {
-  margin: 5px 0 10px;
   background-color: Window;
   color: WindowText;
   position: relative;

--- a/skin/quickreply.css
+++ b/skin/quickreply.css
@@ -12,6 +12,7 @@
 .quickReply ul.inputs {
   list-style-type: none;
   overflow: hidden;
+  transition: all 0.4s ease;
 }
 
 .quickReply ul.inputs li {
@@ -19,6 +20,8 @@
   position: relative;
   width: 50%;
   opacity: 1;
+
+  transition: all 0.4s ease;
 }
 
 .quickReply ul.inputs li.selected {

--- a/skin/quickreply.css
+++ b/skin/quickreply.css
@@ -101,48 +101,6 @@ body.inTab .quickReply li.selected .textarea {
   height: 243px;
 }
 
-.quickReply .popoutTxt {
-  color: GrayText;
-  padding: 0 4px 0 15px;
-}
-
-.quickReply .popout {
-  height: 16px;
-  display: block;
-  position: absolute;
-  bottom: 10px;
-  left: 0;
-  border-width: 1px 1px 0 0;
-  border-color: ThreeDShadow;
-  border-style: solid;
-  background-color: -moz-default-background-color;
-  color: -moz-default-color;
-  cursor: pointer;
-  background-image: linear-gradient(rgba(160, 160, 160, 0.1),
-                                    rgba(160, 160, 160, 0.1));
-  z-index: 101;
-
-  border-radius: 0 3px 0 0;
-}
-
-.quickReply .popout::before {
-  content: "";
-  position: absolute;
-  width: 16px;
-  height: 16px;
-  background-image: url('chrome://conversations/content/i/out.png');
-  background-position: -4px 2px;
-  background-repeat: no-repeat;
-}
-
-.quickReply .selected .popout {
-  width: 16px;
-}
-
-.quickReply .selected .popoutTxt {
-  display: none;
-}
-
 .quickReply .replyHeader,
 .quickReply .replyFooter {
   display: none;

--- a/skin/quickreply.css
+++ b/skin/quickreply.css
@@ -21,9 +21,7 @@
 
 .quickReply ul.inputs li {
   float: left;
-  position: relative;
   width: 50%;
-  opacity: 1;
 
   transition: all 0.4s ease;
 }
@@ -58,10 +56,6 @@
   color: -moz-nativehyperlinktext;
   white-space: nowrap;
   overflow: hidden;
-}
-
-.quickReplyIcon img {
-  vertical-align: top;
 }
 
 .quickReply .textarea {

--- a/skin/quickreply.css
+++ b/skin/quickreply.css
@@ -1,9 +1,3 @@
-/* Hide other actions for the last message */
-
-.message:last-child .messageFooter {
-  display: none;
-}
-
 /* Quick reply */
 
 .quickReply a {
@@ -13,44 +7,21 @@
 
 .quickReply {
   font-size: 1.2rem;
-  background-color: rgba(160, 160, 160, 0.1);
-  border-top: 1px solid ThreeDShadow;
-  padding: 10px 10px;
-  position: relative;
-
-  border-radius: 0 0 5px 5px;
 }
 
 .quickReply ul.inputs {
   list-style-type: none;
   overflow: hidden;
-  padding-right: 140px; /* overridden in stub.xhtml (localized) */
-
-  margin: -10px -5px;
-
   transition: all 0.4s ease;
 }
 
-.quickReply ul.noPad {
-  padding-right: 0 !important;
-}
-
 .quickReply ul.inputs li {
-  display: inline-block;
   float: left;
   position: relative;
   width: 50%;
   opacity: 1;
 
   transition: all 0.4s ease;
-}
-
-.quickReply ul.inputs li.misc {
-  width: auto;
-  position: absolute;
-  right: 10px;
-  width: 140px; /* overridden in stub.xhtml (localized) */
-  overflow: hidden;
 }
 
 .quickReply ul.inputs li.selected {
@@ -63,7 +34,7 @@
 }
 
 .quickReply .textWrap {
-  margin: 10px 5px;
+  margin: 5px 10px 10px 0;
   background-color: Window;
   color: WindowText;
   position: relative;
@@ -143,7 +114,7 @@ body.inTab .quickReply li.selected .textarea {
   display: block;
   position: absolute;
   bottom: 10px;
-  left: 5px;
+  left: 0;
   border-width: 1px 1px 0 0;
   border-color: ThreeDShadow;
   border-style: solid;
@@ -173,21 +144,6 @@ body.inTab .quickReply li.selected .textarea {
 
 .quickReply .selected .popoutTxt {
   display: none;
-}
-
-.quickReply ul.actions {
-  list-style-type: none;
-  padding: 0 0 0 10px;
-  margin: 10px 5px 10px 10px;
-  border-left: 1px solid ThreeDShadow;
-  min-height: 54px;
-}
-
-.quickReply ul.actions li {
-  display: block;
-  width: 100%;
-  margin: 0 0 3px 0;
-  white-space: nowrap;
 }
 
 .quickReply .replyHeader,
@@ -347,10 +303,6 @@ html[xmlns] .cf {
 
 .message:not(.isReplyAllEnabled) .quickReply li.reply {
   width: 100%;
-}
-
-.message:not(.isReplyListEnabled) .quickReply li.list {
-  display: none;
 }
 
 /* misc */

--- a/skin/quickreply.css
+++ b/skin/quickreply.css
@@ -162,25 +162,6 @@ body.inTab .quickReply li.selected .textarea {
   display: block;
 }
 
-/* clearfix */
-
-.cf:after {
-  content: ".";
-  display: block;
-  clear: both;
-  visibility: hidden;
-  line-height: 0;
-  height: 0;
-}
-
-html[xmlns] .cf {
-  display: block;
-}
-
-* html .cf {
-  height: 1%;
-}
-
 /* Quick reply */
 
 .quickReplyRecipients,

--- a/skin/quickreply.css
+++ b/skin/quickreply.css
@@ -12,7 +12,6 @@
 .quickReply ul.inputs {
   list-style-type: none;
   overflow: hidden;
-  transition: all 0.4s ease;
 }
 
 .quickReply ul.inputs li {
@@ -20,8 +19,6 @@
   position: relative;
   width: 50%;
   opacity: 1;
-
-  transition: all 0.4s ease;
 }
 
 .quickReply ul.inputs li.selected {

--- a/skin/quickreply.css
+++ b/skin/quickreply.css
@@ -74,8 +74,6 @@
   color: transparent;
 
   font-size: 1.4rem;
-
-  box-shadow: 0 2px 0 rgba(0, 0, 0, 0.05) inset;
 }
 
 .quickReply .textarea.ease {

--- a/skin/quickreply.css
+++ b/skin/quickreply.css
@@ -7,6 +7,10 @@
 
 .quickReply {
   font-size: 1.2rem;
+  background-color: rgba(160, 160, 160, 0.1);
+  border-top: 1px solid ThreeDShadow;
+  padding: 10px 10px;
+  position: relative;
 }
 
 .quickReply ul.inputs {


### PR DESCRIPTION
I finally good around to work on the footer part of #967. I was actually able to get rid of a lot of code without losing any functionality by just reusing existing parts.

The main change (apart from a lot of styling) is that `.footerActions` is now used in both "normal" messages and quick reply. They also replace the little "open in new window" buttons in the corner of the quick reply textareas. This way there is less code and more UI consitency -- win-win!

I removed one transition (opening a quickreply editor). The issue was that when both textareas are present, the first one still starts out with 100% width and transitions down to 50%. That was just anoying. This issue exists in master.