### PR TITLE
RFC: contact initials in UI

### DIFF
--- a/content/stub.xhtml
+++ b/content/stub.xhtml
@@ -802,6 +802,7 @@
       <div class="messageHeader hbox">
         <div class="shrink-box">
           <div class="star"><svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="chrome://conversations/skin/material-icons.svg#star"></use></svg></div>
+          <abbr class="contactInitials" style="{{dataContactFrom.colorStyle}}">{{dataContactFrom.initials}}</abbr>
           <span class="author">{{tmpl "contactLabel" dataContactFrom}}</span>
           <span class="to hide-with-details"> {{str "to"}} {{tmpl "contactLabel" dataContactsTo}}</span>
           <span class="recipient-tooltips">{{tmpl "contactTooltip" dataContactFrom}}{{tmpl "contactTooltip" dataContactsTo}}</span>
@@ -1109,7 +1110,7 @@
   <script id="contactLabelTemplate" type="text/x-handlebars-template"><![CDATA[<span
     >{{separator}}</span
     ><span class="tooltipWrapper contact"
-      ><span class="contactName" style="{{colorStyle}}"
+      ><span class="contactName"
         >{{#if star}}&#x2605; {{/if}}{{trim name}}{{#if extra}}
         <label xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
           crop="center" class="contactExtra"

--- a/content/stub.xhtml
+++ b/content/stub.xhtml
@@ -804,10 +804,9 @@
           <div class="star"><svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="chrome://conversations/skin/material-icons.svg#star"></use></svg></div>
           {{#if dataContactFrom.avatarIsDefault}}
             <abbr class="contactInitials" style="{{dataContactFrom.colorStyle}}">{{dataContactFrom.initials}}</abbr>
-          {{/if}}
-          {{#unless dataContactFrom.avatarIsDefault}}
+          {{else}}
             <span class="contactAvatar" style="background-image: url('{{dataContactFrom.avatar}}')"> </span>
-          {{/unless}}
+          {{/if}}
           <span class="author">{{tmpl "contactLabel" dataContactFrom}}</span>
           <span class="to hide-with-details"> {{str "to"}} {{tmpl "contactLabel" dataContactsTo}}</span>
           <span class="recipient-tooltips">{{tmpl "contactTooltip" dataContactFrom}}{{tmpl "contactTooltip" dataContactsTo}}</span>

--- a/content/stub.xhtml
+++ b/content/stub.xhtml
@@ -802,7 +802,12 @@
       <div class="messageHeader hbox">
         <div class="shrink-box">
           <div class="star"><svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="chrome://conversations/skin/material-icons.svg#star"></use></svg></div>
-          <abbr class="contactInitials" style="{{dataContactFrom.colorStyle}}">{{dataContactFrom.initials}}</abbr>
+          {{#if dataContactFrom.avatarIsDefault}}
+            <abbr class="contactInitials" style="{{dataContactFrom.colorStyle}}">{{dataContactFrom.initials}}</abbr>
+          {{/if}}
+          {{#unless dataContactFrom.avatarIsDefault}}
+            <span class="contactAvatar" style="background-image: url('{{dataContactFrom.avatar}}')"> </span>
+          {{/unless}}
           <span class="author">{{tmpl "contactLabel" dataContactFrom}}</span>
           <span class="to hide-with-details"> {{str "to"}} {{tmpl "contactLabel" dataContactsTo}}</span>
           <span class="recipient-tooltips">{{tmpl "contactTooltip" dataContactFrom}}{{tmpl "contactTooltip" dataContactsTo}}</span>

--- a/modules/contact.js
+++ b/modules/contact.js
@@ -148,6 +148,7 @@ let ContactMixIn = {
       tooltipName: sanitize((tooltipName != aEmail) ? tooltipName : ""),
       email: sanitize(aEmail),
       avatar: sanitize(this.avatar),
+      avatarIsDefault: this.avatar.substr(0, 6) === 'chrome',
       profiles: this._profiles,
       extra: extra,
       // Parameter aUseColor is optional, and undefined means true

--- a/modules/contact.js
+++ b/modules/contact.js
@@ -125,27 +125,6 @@ ContactManager.prototype = {
       return contact;
     }
   },
-
-  freshColor: function _ContactManager_freshColor(aIsMe) {
-    if (aIsMe) {
-      return "#ed6666";
-    } else {
-      let predefinedColors = ["#ed8866", "#ccc15e", "#9ec269",
-        "#69c2ac", "#66b7ed", "#668ced", "#8866ed", "#cb66ed", "#ed66d9"];
-      if (this._count < predefinedColors.length) {
-        return predefinedColors[this._count++];
-      } else {
-        let r, g, b;
-        // Avoid colors that are too light or too dark.
-        do {
-          r = Math.random();
-          g = Math.random();
-          b = Math.random();
-        } while (Math.sqrt(r*r + b*b + g*g) > .8 || Math.sqrt(r*r + b*b + g*g) < .2)
-        return "rgb("+parseInt(r*255)+","+parseInt(g*255)+","+parseInt(b*255)+")";
-      }
-    }
-  },
 }
 
 let ContactMixIn = {
@@ -332,9 +311,24 @@ let ContactMixIn = {
   },
 };
 
+function freshColor(email) {
+  let hash = 0;
+  for (let i = 0; i < email.length; i++) {
+    let chr = email.charCodeAt(i);
+    hash = ((hash << 5) - hash) + chr;
+    hash &= 0xffff;
+  }
+  let hue = Math.floor(360 * hash / 0xffff);
+  if (hash & 1) {
+    return "hsl(" + hue + ", 55%, 35%)";
+  } else {
+    return "hsl(" + hue + ", 80%, 20%)";
+  }
+};
+
 function ContactFromAB(manager, name, email, /* unused */ position, color) {
   this.emails = [];
-  this.color = color || manager.freshColor(getIdentityForEmail(email));
+  this.color = color || freshColor(email);
 
   this._manager = manager;
   this._name = name; // Initially, the displayed name. Might be enhanced later.

--- a/modules/contact.js
+++ b/modules/contact.js
@@ -70,15 +70,20 @@ const defaultPhotoURI = "chrome://messenger/skin/addressbook/icons/contact-gener
 let Log = setupLogging("Conversations.Contact");
 let strings = new StringBundle("chrome://conversations/locale/message.properties");
 
+/**
+ * If `name` is an email address, get the part before the @.
+ * Then, capitalize the first letter of the first and last word (or the first
+ * two letters of the first word if only one exists).
+ */
 function getInitials(name) {
   name = name.trim().split('@')[0];
-  let parts = name.split(/[ .\-_]/);
+  let words = name.split(/[ .\-_]/);
   let initials = "??";
-  let n = parts.length;
+  let n = words.length;
   if (n == 1) {
-    initials = parts[0].substr(0, 2);
+    initials = words[0].substr(0, 2);
   } else if (n > 1) {
-    initials = parts[0][0] + parts[n - 1][0];
+    initials = words[0][0] + words[n - 1][0];
   }
   return initials.toUpperCase();
 }

--- a/modules/contact.js
+++ b/modules/contact.js
@@ -70,6 +70,19 @@ const defaultPhotoURI = "chrome://messenger/skin/addressbook/icons/contact-gener
 let Log = setupLogging("Conversations.Contact");
 let strings = new StringBundle("chrome://conversations/locale/message.properties");
 
+function getInitials(name) {
+  name = name.trim().split('@')[0];
+  let parts = name.split(/[ .\-_]/);
+  let initials = "??";
+  let n = parts.length;
+  if (n == 1) {
+    initials = parts[0].substr(0, 2);
+  } else if (n > 1) {
+    initials = parts[0][0] + parts[n - 1][0];
+  }
+  return initials.toUpperCase();
+}
+
 function ContactManager() {
   this._cache = {};
   this._colorCache = {};
@@ -151,6 +164,7 @@ let ContactMixIn = {
     let data = {
       showMonospace: aPosition == Contacts.kFrom,
       name: sanitize(name),
+      initials: getInitials(sanitize(name)),
       displayEmail: sanitize(skipEmail ? "" : displayEmail),
       tooltipName: sanitize((tooltipName != aEmail) ? tooltipName : ""),
       email: sanitize(aEmail),
@@ -160,7 +174,7 @@ let ContactMixIn = {
       // Parameter aUseColor is optional, and undefined means true
       colorStyle: ((aUseColor === false)
         ? ""
-        : ("color :" + this.color)),
+        : ("background-color :" + this.color)),
       writeBr: aIsDetail,
       star: aIsDetail && hasCard,
     };

--- a/modules/contact.js
+++ b/modules/contact.js
@@ -325,11 +325,15 @@ function freshColor(email) {
     hash &= 0xffff;
   }
   let hue = Math.floor(360 * hash / 0xffff);
-  if (hash & 1) {
-    return "hsl(" + hue + ", 55%, 35%)";
-  } else {
-    return "hsl(" + hue + ", 80%, 20%)";
-  }
+
+  // try to provide a consistent lightness across hues
+  let lightnessStops = [48, 25, 28, 27, 62, 42];
+  let j = Math.floor(hue / 60);
+  let l1 = lightnessStops[j];
+  let l2 = lightnessStops[(j + 1) % 6];
+  let lightness = Math.floor((hue / 60 - j) * (l2 - l1) + l1);
+
+  return "hsl(" + hue + ", 70%, " + Math.floor(lightness) + "%)";
 };
 
 function ContactFromAB(manager, name, email, /* unused */ position, color) {

--- a/modules/contact.js
+++ b/modules/contact.js
@@ -77,7 +77,9 @@ let strings = new StringBundle("chrome://conversations/locale/message.properties
  */
 function getInitials(name) {
   name = name.trim().split('@')[0];
-  let words = name.split(/[ .\-_]/);
+  let words = name.split(/[ .\-_]/).filter(function(word) {
+    return word;
+  });
   let initials = "??";
   let n = words.length;
   if (n == 1) {

--- a/modules/message.js
+++ b/modules/message.js
@@ -492,6 +492,7 @@ Message.prototype = {
     let data = {
       dataContactFrom: null,
       dataContactsTo: null,
+      initialsFrom: null,
       snippet: null,
       date: null,
       fullDate: null,

--- a/skin/conversation.css
+++ b/skin/conversation.css
@@ -327,13 +327,15 @@ a img {
   cursor: pointer;
 }
 
-.contactInitials {
+.contactInitials,
+.contactAvatar {
   display: inline-block;
   line-height: 2.4;
   min-width: 2.4em;
   border-radius: 1.2em;
   text-align: center;
   color: #fff;
+  background-size: cover;
 }
 
 .smallEmail {

--- a/skin/conversation.css
+++ b/skin/conversation.css
@@ -192,7 +192,6 @@ a img {
 }
 
 .author {
-  color: #ff5959;
   font-weight: bold;
   margin-right: .3rem;
 }
@@ -326,6 +325,15 @@ a img {
 
 .contactName {
   cursor: pointer;
+}
+
+.contactInitials {
+  display: inline-block;
+  line-height: 2.4;
+  min-width: 2.4em;
+  border-radius: 1.2em;
+  text-align: center;
+  color: #fff;
 }
 
 .smallEmail {


### PR DESCRIPTION
**Please do not merge this yet!**

In #967 there are colors cricles with the initials of the sender on each message. This is a first draft of that.

There are two main challanges here:

1. Get the initials from the name/email
2. Get the color for a contact

Interestingly, I did not find any tutorials of how to do this online. But maybe I just used the wrong searchterms…

About (1): There are many issues here. For one, what we have as a name may well be an email adress, a nickname or some auto generated string (e.g. `name at gmail.com`). Second, the semantics of the name are highly dependent on locale. I did some initial draft algorithm, but we should properly test it before merging.

About (2): With the previous implementation, the same person could have a different color in a different conversation. Since the colors are now much more prominent, I thought it would be better to derive the color from the email address. The resulting colors are ok, but I guess a bit of tweaking would be nice.

I believe that some code is dead after this (e.g. around `freshColor`). Some help with cleaning things up would be appreciated.