### PR TITLE
overlay footer actions on message iframe

### DIFF
--- a/skin/conversation.css
+++ b/skin/conversation.css
@@ -655,6 +655,10 @@ span.downwardArrow {
 
 .footerActions {
   float: right;
+  margin-top: -2.3em;
+  background-color: -moz-default-background-color;
+  position: relative;
+  border-top-left-radius: 0.3em;
 }
 
 .footerActions button {


### PR DESCRIPTION
As requested in https://github.com/protz/thunderbird-conversations/pull/1150#issuecomment-280968614 I tried to overlay the footer icons on the message iframe. I am still not sure whether this is a good idea, but with this implementation it should be easier to reason about it.

Here is a screenshot from my setup with a dark message background:

![screenshot from 2017-02-21 09 01 15](https://cloud.githubusercontent.com/assets/202576/23155864/abdd1634-f814-11e6-877b-534108689c1a.png)