### PR TITLE
Cleanup stub XHTML

### DIFF
--- a/content/stub.xhtml
+++ b/content/stub.xhtml
@@ -1345,8 +1345,9 @@
             {{str "sendArchive"}}
           </button>
           <button id="save" style="float:right" onclick="onSave();">{{str "save"}}</button>
-          <a class="discard" href="javascript:" id="discard"
-            onclick="confirmDiscard()">{{str "discard"}}</a>
+          <a class="discard" href="javascript:" id="discard" onclick="confirmDiscard()">
+            {{str "discard"}}
+          </a>
         </div>
       </div>
     </div>

--- a/content/stub.xhtml
+++ b/content/stub.xhtml
@@ -1,1405 +1,1697 @@
-<!DOCTYPE html [
-  <!ENTITY % pageDTD SYSTEM "chrome://conversations/locale/pages.dtd"> %pageDTD;
-]>
-<html xmlns="http://www.w3.org/1999/xhtml"
-  xmlns:xul="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
-<head>
-  <title>Conversation Reader</title>
-  <link rel="stylesheet" type="text/css"
-    href="chrome://messenger/skin/tagColors.css"/>
-  <link rel="stylesheet" type="text/css"
-    href="chrome://conversations/skin/boxflex.css" />
-  <!-- Keep the order! -->
-  <link rel="stylesheet" type="text/css"
-    href="chrome://conversations/skin/conversation.css" />
-  <link rel="stylesheet" type="text/css"
-    href="chrome://conversations/skin/quickreply.css" />
-  <link rel="stylesheet" type="text/css"
-    href="chrome://conversations/skin/tokeninput.css" />
-  <link rel="stylesheet" type="text/css" media="print"
-    href="chrome://conversations/skin/print.css" />
-  <script type="text/javascript"
-    src="chrome://conversations/content/js/jquery-1.12.4.min.js"></script>
-  <script type="text/javascript"
-    src="chrome://conversations/content/js/handlebars-v3.0.0.js"></script>
-  <script type="text/javascript"
-    src="chrome://conversations/content/js/jquery.tokeninput.js"></script>
-  <!-- The two scripts below share the same scope, they were split for the sake
-    of readability. -->
-  <script type="application/javascript;version=1.8"
-    src="chrome://conversations/content/quickReply.js"></script>
-  <script type="application/javascript;version=1.8"
-    src="chrome://conversations/content/stub.completion-ui.js"></script>
-  <script type="application/javascript;version=1.8"
-    src="chrome://conversations/content/stub.compose-ui.js"></script>
-  <script type="application/javascript;version=1.8"
-    src="chrome://conversations/content/stub.compose-ui-bz.js"></script>
-  <script type="application/javascript;version=1.8"
-    src="chrome://conversations/content/handlebars-wrapper.js"></script>
-  <script type="application/javascript;version=1.8"><![CDATA[
-    // Below are mostly UI utility functions.
-    (function ($) {
-      $.fn.vAlign = function(container) {
-        $(document).ready(function () {
-          if (!container)
-            container = "div";
+<!DOCTYPE html [ <!ENTITY % pageDTD SYSTEM "chrome://conversations/locale/pages.dtd"> %pageDTD; ]>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:xul="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
+  <head>
+    <title>Conversation Reader</title>
+    <link rel="stylesheet" type="text/css"
+      href="chrome://messenger/skin/tagColors.css"/>
+    <link rel="stylesheet" type="text/css"
+      href="chrome://conversations/skin/boxflex.css" />
+    <!-- Keep the order! -->
+    <link rel="stylesheet" type="text/css"
+      href="chrome://conversations/skin/conversation.css" />
+    <link rel="stylesheet" type="text/css"
+      href="chrome://conversations/skin/quickreply.css" />
+    <link rel="stylesheet" type="text/css"
+      href="chrome://conversations/skin/tokeninput.css" />
+    <link rel="stylesheet" type="text/css" media="print"
+      href="chrome://conversations/skin/print.css" />
+    <script type="text/javascript"
+      src="chrome://conversations/content/js/jquery-1.12.4.min.js"></script>
+    <script type="text/javascript"
+      src="chrome://conversations/content/js/handlebars-v3.0.0.js"></script>
+    <script type="text/javascript"
+      src="chrome://conversations/content/js/jquery.tokeninput.js"></script>
+    <!-- The two scripts below share the same scope, they were split for the sake
+      of readability. -->
+    <script type="application/javascript;version=1.8"
+      src="chrome://conversations/content/quickReply.js"></script>
+    <script type="application/javascript;version=1.8"
+      src="chrome://conversations/content/stub.completion-ui.js"></script>
+    <script type="application/javascript;version=1.8"
+      src="chrome://conversations/content/stub.compose-ui.js"></script>
+    <script type="application/javascript;version=1.8"
+      src="chrome://conversations/content/stub.compose-ui-bz.js"></script>
+    <script type="application/javascript;version=1.8"
+      src="chrome://conversations/content/handlebars-wrapper.js"></script>
+    <script type="application/javascript;version=1.8">
+      <![CDATA[
+        // Below are mostly UI utility functions.
+        (function($) {
+          $.fn.vAlign = function(container) {
+            $(document)
+              .ready(function() {
+                if (!container)
+                  container = "div";
 
-          this.each(function(i) {
-            $(this).wrap("<div />");
-            var el = $(this);
-            var elh = el.height(); //new element height
-            var ph = el.parent().height(); //parent height
-            var nh = (ph - elh) / 2; //new margin to apply
-            if (!nh) {
-              $(this).unwrap();
-            } else {
-              el.css('margin-top', nh);
-              // don't align again now we've succeeded
-              el.removeClass("align");
-            }
-          });
-        }.bind(this));
-      };
-    })(jQuery);
+                this.each(function(i) {
+                  $(this)
+                    .wrap("<div />");
+                  var el = $(this);
+                  var elh = el.height(); //new element height
+                  var ph = el.parent()
+                    .height(); //parent height
+                  var nh = (ph - elh) / 2; //new margin to apply
+                  if (!nh) {
+                    $(this)
+                      .unwrap();
+                  } else {
+                    el.css('margin-top', nh);
+                    // don't align again now we've succeeded
+                    el.removeClass("align");
+                  }
+                });
+              }.bind(this));
+          };
+        })(jQuery);
 
-    function clearMenu() {
-      for (let menu of document.getElementsByClassName("menu")) {
-        menu.style.display = "none";
-      }
-    }
+        function clearMenu() {
+          for (let menu of document.getElementsByClassName("menu")) {
+            menu.style.display = "none";
+          }
+        }
 
-    function displayMenu(event) {
-      let target = event.target;
-      // This is a hack to make it work when we click the downwardArrow.
-      if (!target.nextElementSibling)
-        target = target.parentNode;
-      let menu = target.nextElementSibling;
-      let menuWasVisible = (menu.style.display == "-moz-box")
-          || (menu.style.display == "inline-block")
-          || (menu.style.display == "block");
-      clearMenu();
-      if (!menuWasVisible) {
-        menu.style.display = "-moz-box";
-        event.stopPropagation();
-      }
-    }
-
-    $(document).ready(function () {
-      document.addEventListener("click", function (event) {
-        clearMenu();
-      }, false);
-      document.addEventListener("keypress", function (event) {
-        if (event.keyCode == KeyEvent.DOM_VK_ESCAPE)
+        function displayMenu(event) {
+          let target = event.target;
+          // This is a hack to make it work when we click the downwardArrow.
+          if (!target.nextElementSibling)
+            target = target.parentNode;
+          let menu = target.nextElementSibling;
+          let menuWasVisible = (menu.style.display == "-moz-box") ||
+            (menu.style.display == "inline-block") ||
+            (menu.style.display == "block");
           clearMenu();
-      }, false);
-    });
-
-    function alignAttachments(aMsgNode) {
-      $(aMsgNode._domNode).find(".align").vAlign();
-    }
-
-    // This function only works for our message nodes, use $(...).offset() for
-    //  more complicated computations.
-    function offsetFromTop (aNode) {
-      let offset = aNode.offsetTop || 0;
-      let parent = aNode.parentNode;
-      while (parent && !(parent instanceof HTMLDocument)) {
-        let style = window.getComputedStyle(parent, null);
-        if (style.position == "relative")
-          offset += parent.offsetTop;
-        parent = parent.parentNode;
-      }
-      return offset;
-    }
-
-    function scrollNodeIntoView (aNode) {
-      let offset = offsetFromTop(aNode);
-      // The header is 44px high (yes, this is harcodeadly ugly).
-      window.scrollTo(0, offset + 5 - 44);
-    }
-
-    function toggleBlock(event, showtext, hidetext) {
-      let link = event.target;
-      let div = link.nextSibling;
-      let cs = window.getComputedStyle(div, null);
-      if (div.style.display == "none") {
-        link.textContent = "- "+hidetext+" -";
-        div.style.display = "";
-        let h = div.getBoundingClientRect().height +
-          parseFloat(cs.marginTop) + parseFloat(cs.marginBottom);
-        return h;
-      } else {
-        let h = div.getBoundingClientRect().height;
-        h += parseFloat(cs.marginTop);
-        h += parseFloat(cs.marginBottom);
-        link.textContent = "- "+showtext+" -";
-        div.style.display = "none";
-        return -h;
-      }
-    }
-
-    const kPopupTimeout = 400;
-
-    // This only works for contact tooltips. The "more" menu is treated like a
-    //  real menu (it uses displayMenu and falls under clearMenu's operations),
-    //  and the reply menu with various choices is also treated like a menu.
-    // It turns out the "more" menu reuses the tooltip style for various
-    //  reasons, mostly to keep the same appearance, so we differentiate that
-    //  one with a tooltip-menu extra class.
-    function enableTooltips(aMsg) {
-      let $aMsgNode = $(aMsg._domNode);
-
-      let self = this;
-
-      // enable tooltip for all contacts but recipients
-      $aMsgNode.find(':not(.recipient-tooltips) .tooltip').each(function () {
-        // "contact" is a hypothetical "contact" link that, when
-        // hovered/clicked, starts the interaction with the tooltip
-        let $tooltip = $(this);
-
-        if ($tooltip.hasClass("tooltip-menu"))
-          return;
-
-        let $contact = $tooltip.prev();
-        if ($contact.hasClass("contactBr"))
-          $contact = $contact.prev();
-
-        self.setTooltipEventHandlers(aMsg, $contact, $tooltip, false);
-      });
-
-      let $contactLabels = $aMsgNode.find('.to .contactName');
-
-      // enable tooltip for recipient contacts
-      $aMsgNode.find('.recipient-tooltips .tooltip').each(function (index) {
-        // "contact" is a hypothetical "contact" link that, when
-        // hovered/clicked, starts the interaction with the tooltip
-        let $tooltip = $(this);
-
-        let $contact = index > 0
-          ? $contactLabels.eq(index-1)
-          : $aMsgNode.find('.author .contactName');
-
-        self.setTooltipEventHandlers(aMsg, $contact, $tooltip, true);
-      });
-    }
-
-    // Set events on a contact and its respective tooltip so to show/hide
-    //  the tooltip over the contact when mouse enters/leaves their areas.
-    function setTooltipEventHandlers(aMsg, $contact, $tooltip, isRecipient) {
-      let timeout;
-
-      $contact.hover(function() {
-        if (aMsg.collapsed)
-          return;
-
-        clearTimeout(timeout);
-
-        timeout = setTimeout(function () {
-          if (isRecipient) {
-            // move tooltip close to its respective recipient contact
-            let contactWrapperPosition = $contact.parents('.tooltipWrapper').position();
-            let $tooltipWrapper = $tooltip.parents('.contactTooltipWrapper');
-            $tooltipWrapper.css(contactWrapperPosition);
+          if (!menuWasVisible) {
+            menu.style.display = "-moz-box";
+            event.stopPropagation();
           }
-
-          $tooltip.fadeIn();
-        }, kPopupTimeout);
-
-      }, function() {
-        clearTimeout(timeout);
-
-        timeout = setTimeout(function () {
-          $tooltip.fadeOut();
-        }, kPopupTimeout);
-      });
-
-      $tooltip.hover(function () {
-        clearTimeout(timeout);
-
-      }, function () {
-        if ($tooltip.is(":visible")) {
-          clearTimeout(timeout);
-
-          timeout = setTimeout(function () {
-            $tooltip.fadeOut();
-          }, kPopupTimeout);
         }
-      });
-    }
 
-    function cleanup() {
-      // These shouldn't be necessary because we're blasting away everything by
-      //  setting .innerHTML BUT jQuery won't remove its persistent event
-      //  listeners if we don't do that which will in turn cause memory leaks!
-      // Indeed, the listeners are actually closures on Message instances. These
-      //  contain a pointer to their parent Conversation, so that would prevent
-      //  the GC from collecting anything! Argh!
-      $("#messageList").empty();
-    }
-
-    function openLink(event) {
-      gMessenger.launchExternalURL(event.originalTarget.getAttribute("href"));
-    }
-
-    document.addEventListener("focus", function (event) {
-      /* This is a persistent event listener. It can operate multiple
-       * times. We have the invariant that for a given conversation, there's at
-       * most one such element (recycling doesn't use tabindex 1). */
-      let msgNode = document.querySelector(".message[tabindex=\"1\"]");
-      if (!msgNode)
-        return;
-
-      /* Restore the proper tab order. This event is fired *after* the
-       * right message has been focused in Gecko 1.9.2, *before* the right
-       * message has been focused in Gecko 1.9.1 (so it's basically
-       * useless). */
-      let msgNodes = document.getElementsByClassName("message");
-      let index = Array.prototype.indexOf.call(msgNodes, msgNode);
-      if (index != -1) {
-        msgNode.setAttribute("tabindex", index + 2);
-      }
-    }, true);
-
-    function closeTab() {
-      let browser = window.frameElement;
-      let tabmail = window.top.document.getElementById("tabmail");
-      let tabs = tabmail.tabInfo;
-      let candidates = tabs.filter(x => x.browser == browser);
-      if (candidates.length == 1) {
-        tabmail.closeTab(candidates[0]);
-      } else {
-        Log.error("Couldn't find a tab to close...");
-      }
-    }
-
-    // Below are event listeners for various actions. There is some logic
-    //  involved, and they may talk to other parts of the code.
-
-    // This property is now set from the outside. This allows stub.html to
-    //  be used either in a standalone tab or in the multimessage pane.
-    // let Conversations = window.top.Conversations;
-
-    Components.utils.import("resource:///modules/mailServices.js");
-    Components.utils.import("resource://conversations/modules/stdlib/misc.js");
-    Components.utils.import("resource://conversations/modules/stdlib/msgHdrUtils.js");
-    Components.utils.import("resource://conversations/modules/prefs.js");
-    Components.utils.import("resource://conversations/modules/log.js");
-    Components.utils.import("resource://conversations/modules/misc.js");
-    Components.utils.import("resource://conversations/modules/contact.js");
-
-    Log = setupLogging("Conversations.Stub");
-    // Declare with var, not let, so that it's in the global scope, not the lexical scope.
-    var isInTab = false;
-
-    wrapHandlebars();
-
-    $(document).ready(function () {
-      let stylesheet;
-      for (let x of document.styleSheets) {
-        if (String.indexOf(x.href, "/conversation.css") >= 0) {
-          stylesheet = x;
-          break;
-        }
-      }
-
-      if (stylesheet) {
-        if (Prefs.tweak_chrome) {
-          // Set the root size to 10px on Linux, and equivalent font sizes on
-          // other platforms.
-          if (isOSX)
-            stylesheet.insertRule("html { font-size: 66.6%; }", 0);
-          else if (isWindows)
-            stylesheet.insertRule("html { font-size: 70%; }", 0);
-          else
-            stylesheet.insertRule("html { font-size: 62.5%; }", 0);
-        } else {
-          stylesheet.insertRule("html { font-size: 83.3%; }", 0);
-        }
-      } else {
-        Log.error("No stylesheet. This is unexpected.");
-      }
-    });
-
-    // Mark the current conversation as read/unread. The conversation driver
-    //  takes care of setting the right class on us whenever the state
-    //  changes...
-    function toggleRead(event) {
-      let $span = $(event.target).find(".icon.read");
-      if ($span.hasClass("unread")) {
-        Conversations.currentConversation.read = true;
-        $span.removeClass("unread");
-      } else {
-        Conversations.currentConversation.read = false;
-        $span.addClass("unread");
-        markReadInView.disable();
-      }
-    }
-
-    function expandCollapse(event) {
-      let $span = $(event.target).find(".icon.expand");
-      if ($span.hasClass("collapse")) {
-        for (let { message } of Conversations.currentConversation.messages) {
-          message.collapse();
-        }
-        $span.removeClass("collapse");
-      } else {
-        for (let { message } of Conversations.currentConversation.messages) {
-          message.expand();
-        }
-        $span.addClass("collapse");
-      }
-    }
-
-    function archiveToolbar(event) {
-      if (isInTab || Prefs.operate_on_conversations)
-        archiveConversation(event);
-      else
-        msgHdrsArchive(topMail3Pane(window).gFolderDisplay.selectedMessages);
-    }
-
-    function archiveConversation(event) {
-      msgHdrsArchive(Conversations.currentConversation.msgHdrs);
-      if (!isInTab)
-        topMail3Pane(window).SetFocusThreadPane(event);
-    }
-
-    function deleteToolbar(event) {
-      if (isInTab || Prefs.operate_on_conversations)
-        deleteConversation();
-      else
-        msgHdrsDelete(topMail3Pane(window).gFolderDisplay.selectedMessages);
-    }
-
-    function deleteConversation(event) {
-      msgHdrsDelete(Conversations.currentConversation.msgHdrs);
-      if (isInTab)
-        closeTab();
-      topMail3Pane(window).SetFocusThreadPane(event);
-    }
-
-    function forwardConversation(event) {
-      let conv = Conversations.currentConversation;
-      let fields = Cc["@mozilla.org/messengercompose/composefields;1"]
-                      .createInstance(Components.interfaces.nsIMsgCompFields);
-      fields.characterSet = "UTF-8";
-      fields.bodyIsAsciiOnly = false;
-      fields.forcePlainText = false;
-      Conversations.currentConversation.exportAsHtml(function (html) {
-        fields.body = html;
-        let params = Cc["@mozilla.org/messengercompose/composeparams;1"]
-                        .createInstance(Ci.nsIMsgComposeParams);
-        params.format = Ci.nsIMsgCompFormat.HTML;
-        params.composeFields = fields;
-        return MailServices.compose.OpenComposeWindowWithParams(null, params);
-      });
-    }
-
-    let oldPrint = window.print;
-
-    function printConversation(event) {
-      for (let { message: m } of Conversations.currentConversation.messages) {
-        m.dumpPlainTextForPrinting();
-      }
-      oldPrint();
-    }
-
-    window.print = printConversation;
-
-    function junkConversation(event) {
-      // This callback is only activated when the conversation is not a
-      //  conversation in a tab AND there's only one message in the conversation,
-      //  i.e. the currently selected message
-      topMail3Pane(window).JunkSelectedMessages(true);
-      $("#conversationHeader").addClass("not-junkable");
-      topMail3Pane(window).SetFocusThreadPane(event);
-    }
-
-    const kGalleryUrl = "chrome://conversations/content/gallery/index.html";
-
-    function galleryView(uri) {
-      let tabmail = topMail3Pane(window).document.getElementById("tabmail");
-      tabmail.openTab("chromeTab", {
-        chromePage: kGalleryUrl+"?uri="+uri,
-      });
-    }
-
-    /**
-     * This function gathers various information, encodes it in a URL query
-     * string, and then opens a regular chrome tab that contains our
-     * conversation.
-     */
-    function detachTab(event) {
-      let tabmail = topMail3Pane(window).document.getElementById("tabmail");
-      let willExpand = $("textarea").parent().hasClass("expand") && startedEditing();
-      // Pick _initialSet and not msgHdrs so as to enforce the invariant
-      //  that the messages from _initialSet are in the current view.
-      let urls =
-        Conversations.currentConversation._initialSet.map(x => msgHdrGetUri(x)).join(",");
-      let queryString = "?urls="+encodeURIComponent(urls)
-        +"&willExpand="+Number(willExpand);
-      // First, save the draft, and once it's saved, then move on to opening the
-      // conversation in a new tab...
-      onSave(function () {
-        openConversationInTabOrWindow(kStubUrl+queryString);
-      });
-    }
-
-    /**
-     * This function finds the right node that holds the attachment information
-     * and returns its information.
-     */
-    function getCurrentAttInfo() {
-      let node = topMail3Pane(window).document.popupNode;
-      while (!node.attInfo)
-        node = node.parentNode;
-      return node.attInfo;
-    }
-
-    /**
-     * That big event handler tries to parse URL query parameters, and then acts
-     * upon these, by firing a conversation on its own. This is a very
-     * stripped-down version of the logic that's in monkeypatch.js, and it
-     * serves the purpose of being able to create a standalone conversation view
-     * in a new tab.
-     */
-    $(document).ready(function () {
-      // I just imagined Javascript would have some function for that
-      // built-in... looks like even jQuery doesn't have it.
-      let params = decodeUrlParameters(document.location.href);
-
-      // Oh, are we expected to build a conversation on our own? Let's do it,
-      // yay!
-      if ("urls" in params) {
-        try {
-          let scrollMode = ("scrollMode" in params)
-            ? parseInt(params.scrollMode)
-            : Prefs.kScrollUnreadOrLast;
-          /* If we start up Thunderbird with a saved conversation tab, then we
-           * have no selected message. Fallback to the usual mode. */
-          if (scrollMode == Prefs.kScrollSelected &&
-              !topMail3Pane(window).gFolderDisplay.selectedMessage)
-            scrollMode = Prefs.kScrollUnreadOrLast;
-
-          isInTab = true;
-          if (window.frameElement)
-            window.frameElement.setAttribute("tooltip", "aHTMLTooltip");
-          let mainWindow = topMail3Pane(window);
-          let willExpand = parseInt(params.willExpand);
-          let msgHdrs = params.urls.split(",").map(x => msgUriToMsgHdr(x))
-                                              .filter(x => x != null && x.messageId);
-          // It might happen that there are no messages left...
-          if (!msgHdrs.length) {
-            document.getElementById("messageList").textContent =
-              strings.get("messageMovedOrDeletedConversation");
-          } else {
-            window.Conversations = {
-              currentConversation: null,
-              counter: 0,
-            };
-            let freshConversation = new mainWindow.Conversations.monkeyPatch._Conversation(
-              window,
-              msgHdrs,
-              scrollMode,
-              ++Conversations.counter
-            );
-            let browser = window.frameElement;
-            // Because Thunderbird still hasn't fixed that...
-            if (browser)
-              browser.setAttribute("context", "mailContext");
-            freshConversation.outputInto(window, function (aConversation) {
-              // This is a stripped-down version of what's in monkeypatch.js,
-              //  make sure the two are in sync!
-              Conversations.currentConversation = aConversation;
-              aConversation.completed = true;
-              registerQuickReply();
-              // That's why we saved it before...
-              newComposeSessionByDraftIf();
-              if (willExpand)
-                expandQuickReply();
-              // Create a new rule that will override the default rule, so that
-              // the expanded quick reply is twice higher.
-              document.body.classList.add("inTab");
-              // We can never junk a conversation in a new tab, because the junk
-              // command only operates on selected messages, and we're not in a
-              // 3pane context anymore.
-              document.getElementById("conversationHeader").classList.add("not-junkable");
-              // Do this now so as to not defeat the whole expand/collapse
-              // logic.
-              if (Prefs.getBool("mailnews.mark_message_read.auto")) {
-                setTimeout(function () {
-                  msgHdrsMarkAsRead(msgHdrs, true);
-                }, Prefs.getInt("mailnews.mark_message_read.delay.interval")
-                   * Prefs.getBool("mailnews.mark_message_read.delay") * 1000);
-              }
-            });
-          }
-        } catch (e) {
-          Log.debug(e);
-          dumpCallStack(e);
-        }
-      } else if ("quickCompose" in params) {
-        masqueradeAsQuickCompose();
-      }
-    });
-
-    var isQuickCompose = false;
-
-    /* This is our new hack: reuse this file to provide a standalone composition
-     * window. Why? Because it uses gloda autocomplete and provides a
-     * no-frills composition experience. */
-    function masqueradeAsQuickCompose() {
-      isQuickCompose = true;
-      document.title = strings.get("write");
-      document.querySelector("#conversationHeader").style.display = "none";
-      document.querySelector(".bottom-links").style.display = "none";
-      document.querySelector("#messageList").style.marginTop = "0";
-      document.querySelector("#messageList").classList.add("quickCompose");
-      tmpl("#quickReplyTemplate").appendTo($("#messageList"));
-      $(".replyAll, #save, .replyMethod").remove();
-
-      // TODO figure out why this timeout is needed
-      setTimeout(function () {
-        showQuickReply.call($(".reply.expand"));
-        gComposeSession = createComposeSession(x => x.new());
-        revealCompositionFields();
-        editFields("to");
-      }, 0);
-
-      window.Conversations = {
-        currentConversation: {
-          msgHdrs: [],
-          id: null,
-        },
-      };
-
-      document.querySelector(".quickReply").addEventListener("keypress", function (event) {
-        switch (event.keyCode) {
-          case KeyEvent.DOM_VK_RETURN:
-            if (isAccel(event)) {
-              if (event.shiftKey)
-                gComposeSession.send({ archive: true });
-              else
-                gComposeSession.send();
-            }
-            break;
-        }
-      }, false);
-
-
-      let data = [];
-
-      // Push a new contact item in the list
-      let pushNewPopularContacts = function (n) {
-        let items = data.splice(0, n);
-        let nodes = tmpl("#popularContactTemplate", items);
-
-        items.forEach(function(data2, i) {
-          let data = data2;
-          let node = nodes.eq(i);
-          Log.debug("Adding", data.name, data.email);
-
-          node.find(".popularRemove").click(function () {
-            Log.debug("Removing", data.name, data.email);
-            // Mark it in the prefs
-            let unwantedRecipients = JSON.parse(Prefs.getString("conversations.unwanted_recipients"));
-            unwantedRecipients[data.email] = null;
-            Prefs.setString("conversations.unwanted_recipients",
-              JSON.stringify(unwantedRecipients));
-            // Update the UI
-            $(this).closest(".popularContact").remove();
-            pushNewPopularContacts(1);
-          });
-
-          node.find(".popularName").click(function () {
-            // Get all the current parameters
-            let to = JSON.parse($("#to").val());
-            let cc = JSON.parse($("#cc").val());
-            let bcc = JSON.parse($("#bcc").val());
-            // Append our new value
-            to.push(MailServices.headerParser.makeMimeAddress(data.name, data.email));
-            // Re-set everything
-            let format = items => items.map(parseMimeLine)
-                                       .map(([{ name, email }]) => asToken(null, name, email, null));
-            setupAutocomplete(format(to), format(cc), format(bcc));
-            // Remove the node!
-            node.remove();
-            pushNewPopularContacts(1);
-          });
-
+        $(document)
+        .ready(function() {
+          document.addEventListener("click", function(event) {
+            clearMenu();
+          }, false);
+          document.addEventListener("keypress", function(event) {
+            if (event.keyCode == KeyEvent.DOM_VK_ESCAPE)
+              clearMenu();
+          }, false);
         });
 
-        nodes.appendTo($(".quickReplyContactsBox"));
-      };
+        function alignAttachments(aMsgNode) {
+          $(aMsgNode._domNode)
+            .find(".align")
+            .vAlign();
+        }
 
-      $(".quickReplyContactsMoreLink").click(() => pushNewPopularContacts(10));
+        // This function only works for our message nodes, use $(...).offset() for
+        //  more complicated computations.
+        function offsetFromTop(aNode) {
+          let offset = aNode.offsetTop || 0;
+          let parent = aNode.parentNode;
+          while (parent && !(parent instanceof HTMLDocument)) {
+            let style = window.getComputedStyle(parent, null);
+            if (style.position == "relative")
+              offset += parent.offsetTop;
+            parent = parent.parentNode;
+          }
+          return offset;
+        }
 
-      // Fill in the "10 most popular contacts" thing
-      let contactQuery = Gloda.newQuery(Gloda.NOUN_CONTACT);
-      contactQuery.orderBy("-popularity").limit(100);
-      let contactCollection = contactQuery.getCollection({
-        onItemsAdded: function(aItems, aCollection) {
-        },
-        onItemsModified: function(aItems, aCollection) {
-        },
-        onItemsRemoved: function(aItems, aCollection) {
-        },
-        onQueryCompleted: function(aCollection) {
-          let items = aCollection.items;
-          let unwantedRecipients = JSON.parse(Prefs.getString("conversations.unwanted_recipients"));
+        function scrollNodeIntoView(aNode) {
+          let offset = offsetFromTop(aNode);
+          // The header is 44px high (yes, this is harcodeadly ugly).
+          window.scrollTo(0, offset + 5 - 44);
+        }
 
-          for (let contact of items) {
-            if (contact.identities.length) {
-              let id = contact.identities[0];
-              let photoForAbCard = function (card) {
-                if (!card)
-                  return defaultPhotoURI;
-                let url = card.getProperty("PhotoURI", "");
-                if (!url)
-                  return defaultPhotoURI;
-                return url;
-              };
-              if (id.kind == "email" && !(id.value in unwantedRecipients)) {
-                // Log.debug("Pushing", id.value, contact.name, contact.popularity);
-                data.push({
-                  email: id.value,
-                  name: contact.name,
-                  photo: photoForAbCard(id.abCard),
-                });
+        function toggleBlock(event, showtext, hidetext) {
+          let link = event.target;
+          let div = link.nextSibling;
+          let cs = window.getComputedStyle(div, null);
+          if (div.style.display == "none") {
+            link.textContent = "- " + hidetext + " -";
+            div.style.display = "";
+            let h = div.getBoundingClientRect()
+              .height +
+              parseFloat(cs.marginTop) + parseFloat(cs.marginBottom);
+            return h;
+          } else {
+            let h = div.getBoundingClientRect()
+              .height;
+            h += parseFloat(cs.marginTop);
+            h += parseFloat(cs.marginBottom);
+            link.textContent = "- " + showtext + " -";
+            div.style.display = "none";
+            return -h;
+          }
+        }
+
+        const kPopupTimeout = 400;
+
+        // This only works for contact tooltips. The "more" menu is treated like a
+        //  real menu (it uses displayMenu and falls under clearMenu's operations),
+        //  and the reply menu with various choices is also treated like a menu.
+        // It turns out the "more" menu reuses the tooltip style for various
+        //  reasons, mostly to keep the same appearance, so we differentiate that
+        //  one with a tooltip-menu extra class.
+        function enableTooltips(aMsg) {
+          let $aMsgNode = $(aMsg._domNode);
+
+          let self = this;
+
+          // enable tooltip for all contacts but recipients
+          $aMsgNode.find(':not(.recipient-tooltips) .tooltip')
+            .each(function() {
+              // "contact" is a hypothetical "contact" link that, when
+              // hovered/clicked, starts the interaction with the tooltip
+              let $tooltip = $(this);
+
+              if ($tooltip.hasClass("tooltip-menu"))
+                return;
+
+              let $contact = $tooltip.prev();
+              if ($contact.hasClass("contactBr"))
+                $contact = $contact.prev();
+
+              self.setTooltipEventHandlers(aMsg, $contact, $tooltip, false);
+            });
+
+          let $contactLabels = $aMsgNode.find('.to .contactName');
+
+          // enable tooltip for recipient contacts
+          $aMsgNode.find('.recipient-tooltips .tooltip')
+            .each(function(index) {
+              // "contact" is a hypothetical "contact" link that, when
+              // hovered/clicked, starts the interaction with the tooltip
+              let $tooltip = $(this);
+
+              let $contact = index > 0 ?
+                $contactLabels.eq(index - 1) :
+                $aMsgNode.find('.author .contactName');
+
+              self.setTooltipEventHandlers(aMsg, $contact, $tooltip, true);
+            });
+        }
+
+        // Set events on a contact and its respective tooltip so to show/hide
+        //  the tooltip over the contact when mouse enters/leaves their areas.
+        function setTooltipEventHandlers(aMsg, $contact, $tooltip, isRecipient) {
+          let timeout;
+
+          $contact.hover(function() {
+            if (aMsg.collapsed)
+              return;
+
+            clearTimeout(timeout);
+
+            timeout = setTimeout(function() {
+              if (isRecipient) {
+                // move tooltip close to its respective recipient contact
+                let contactWrapperPosition = $contact.parents(
+                    '.tooltipWrapper')
+                  .position();
+                let $tooltipWrapper = $tooltip.parents(
+                  '.contactTooltipWrapper');
+                $tooltipWrapper.css(contactWrapperPosition);
               }
+
+              $tooltip.fadeIn();
+            }, kPopupTimeout);
+
+          }, function() {
+            clearTimeout(timeout);
+
+            timeout = setTimeout(function() {
+              $tooltip.fadeOut();
+            }, kPopupTimeout);
+          });
+
+          $tooltip.hover(function() {
+            clearTimeout(timeout);
+
+          }, function() {
+            if ($tooltip.is(":visible")) {
+              clearTimeout(timeout);
+
+              timeout = setTimeout(function() {
+                $tooltip.fadeOut();
+              }, kPopupTimeout);
+            }
+          });
+        }
+
+        function cleanup() {
+          // These shouldn't be necessary because we're blasting away everything by
+          //  setting .innerHTML BUT jQuery won't remove its persistent event
+          //  listeners if we don't do that which will in turn cause memory leaks!
+          // Indeed, the listeners are actually closures on Message instances. These
+          //  contain a pointer to their parent Conversation, so that would prevent
+          //  the GC from collecting anything! Argh!
+          $("#messageList")
+            .empty();
+        }
+
+        function openLink(event) {
+          gMessenger.launchExternalURL(event.originalTarget.getAttribute("href"));
+        }
+
+        document.addEventListener("focus", function(event) {
+          /* This is a persistent event listener. It can operate multiple
+           * times. We have the invariant that for a given conversation, there's at
+           * most one such element (recycling doesn't use tabindex 1). */
+          let msgNode = document.querySelector(".message[tabindex=\"1\"]");
+          if (!msgNode)
+            return;
+
+          /* Restore the proper tab order. This event is fired *after* the
+           * right message has been focused in Gecko 1.9.2, *before* the right
+           * message has been focused in Gecko 1.9.1 (so it's basically
+           * useless). */
+          let msgNodes = document.getElementsByClassName("message");
+          let index = Array.prototype.indexOf.call(msgNodes, msgNode);
+          if (index != -1) {
+            msgNode.setAttribute("tabindex", index + 2);
+          }
+        }, true);
+
+        function closeTab() {
+          let browser = window.frameElement;
+          let tabmail = window.top.document.getElementById("tabmail");
+          let tabs = tabmail.tabInfo;
+          let candidates = tabs.filter(x => x.browser == browser);
+          if (candidates.length == 1) {
+            tabmail.closeTab(candidates[0]);
+          } else {
+            Log.error("Couldn't find a tab to close...");
+          }
+        }
+
+        // Below are event listeners for various actions. There is some logic
+        //  involved, and they may talk to other parts of the code.
+
+        // This property is now set from the outside. This allows stub.html to
+        //  be used either in a standalone tab or in the multimessage pane.
+        // let Conversations = window.top.Conversations;
+
+        Components.utils.import("resource:///modules/mailServices.js"); Components.utils
+        .import("resource://conversations/modules/stdlib/misc.js"); Components.utils
+        .import("resource://conversations/modules/stdlib/msgHdrUtils.js"); Components
+        .utils.import("resource://conversations/modules/prefs.js"); Components.utils
+        .import("resource://conversations/modules/log.js"); Components.utils.import(
+          "resource://conversations/modules/misc.js"); Components.utils.import(
+          "resource://conversations/modules/contact.js");
+
+        Log = setupLogging("Conversations.Stub");
+        // Declare with var, not let, so that it's in the global scope, not the lexical scope.
+        var isInTab = false;
+
+        wrapHandlebars();
+
+        $(document)
+        .ready(function() {
+          let stylesheet;
+          for (let x of document.styleSheets) {
+            if (String.indexOf(x.href, "/conversation.css") >= 0) {
+              stylesheet = x;
+              break;
             }
           }
 
-          pushNewPopularContacts(10);
-        },
-      }, null);
-      contactCollection.becomeExplicit();
+          if (stylesheet) {
+            if (Prefs.tweak_chrome) {
+              // Set the root size to 10px on Linux, and equivalent font sizes on
+              // other platforms.
+              if (isOSX)
+                stylesheet.insertRule("html { font-size: 66.6%; }", 0);
+              else if (isWindows)
+                stylesheet.insertRule("html { font-size: 70%; }", 0);
+              else
+                stylesheet.insertRule("html { font-size: 62.5%; }", 0);
+            } else {
+              stylesheet.insertRule("html { font-size: 83.3%; }", 0);
+            }
+          } else {
+            Log.error("No stylesheet. This is unexpected.");
+          }
+        });
 
-      // Misc
-      if (!top.opener) {
-        window.frameElement.setAttribute("tooltip", "aHTMLTooltip");
-        window.frameElement.setAttribute("context", "mailContext");
-      }
-    }
+        // Mark the current conversation as read/unread. The conversation driver
+        //  takes care of setting the right class on us whenever the state
+        //  changes...
+        function toggleRead(event) {
+          let $span = $(event.target)
+            .find(".icon.read");
+          if ($span.hasClass("unread")) {
+            Conversations.currentConversation.read = true;
+            $span.removeClass("unread");
+          } else {
+            Conversations.currentConversation.read = false;
+            $span.addClass("unread");
+            markReadInView.disable();
+          }
+        }
 
-    // Mark a message as read if a user scrolls past top and bottom of an
-    // unread message.
-    function markReadInView(event) {
-      if (event.type == "keydown") {
-        // for scroll by keyboard shortcut
-        switch (event.which) {
-          case KeyEvent.DOM_VK_SPACE:
-          case KeyEvent.DOM_VK_TAB:
-          case KeyEvent.DOM_VK_PAGE_UP:
-          case KeyEvent.DOM_VK_PAGE_DOWN:
-          case KeyEvent.DOM_VK_UP:
-          case KeyEvent.DOM_VK_DOWN:
-          case KeyEvent.DOM_VK_F:
-          case KeyEvent.DOM_VK_B:
-            break;
-          default:
+        function expandCollapse(event) {
+          let $span = $(event.target)
+            .find(".icon.expand");
+          if ($span.hasClass("collapse")) {
+            for (let {
+                message
+              }
+              of Conversations.currentConversation.messages) {
+              message.collapse();
+            }
+            $span.removeClass("collapse");
+          } else {
+            for (let {
+                message
+              }
+              of Conversations.currentConversation.messages) {
+              message.expand();
+            }
+            $span.addClass("collapse");
+          }
+        }
+
+        function archiveToolbar(event) {
+          if (isInTab || Prefs.operate_on_conversations)
+            archiveConversation(event);
+          else
+            msgHdrsArchive(topMail3Pane(window)
+              .gFolderDisplay.selectedMessages);
+        }
+
+        function archiveConversation(event) {
+          msgHdrsArchive(Conversations.currentConversation.msgHdrs);
+          if (!isInTab)
+            topMail3Pane(window)
+            .SetFocusThreadPane(event);
+        }
+
+        function deleteToolbar(event) {
+          if (isInTab || Prefs.operate_on_conversations)
+            deleteConversation();
+          else
+            msgHdrsDelete(topMail3Pane(window)
+              .gFolderDisplay.selectedMessages);
+        }
+
+        function deleteConversation(event) {
+          msgHdrsDelete(Conversations.currentConversation.msgHdrs);
+          if (isInTab)
+            closeTab();
+          topMail3Pane(window)
+            .SetFocusThreadPane(event);
+        }
+
+        function forwardConversation(event) {
+          let conv = Conversations.currentConversation;
+          let fields = Cc["@mozilla.org/messengercompose/composefields;1"]
+            .createInstance(Components.interfaces.nsIMsgCompFields);
+          fields.characterSet = "UTF-8";
+          fields.bodyIsAsciiOnly = false;
+          fields.forcePlainText = false;
+          Conversations.currentConversation.exportAsHtml(function(html) {
+            fields.body = html;
+            let params = Cc["@mozilla.org/messengercompose/composeparams;1"]
+              .createInstance(Ci.nsIMsgComposeParams);
+            params.format = Ci.nsIMsgCompFormat.HTML;
+            params.composeFields = fields;
+            return MailServices.compose.OpenComposeWindowWithParams(null,
+              params);
+          });
+        }
+
+        let oldPrint = window.print;
+
+        function printConversation(event) {
+          for (let {
+              message: m
+            }
+            of Conversations.currentConversation.messages) {
+            m.dumpPlainTextForPrinting();
+          }
+          oldPrint();
+        }
+
+        window.print = printConversation;
+
+        function junkConversation(event) {
+          // This callback is only activated when the conversation is not a
+          //  conversation in a tab AND there's only one message in the conversation,
+          //  i.e. the currently selected message
+          topMail3Pane(window)
+            .JunkSelectedMessages(true);
+          $("#conversationHeader")
+            .addClass("not-junkable");
+          topMail3Pane(window)
+            .SetFocusThreadPane(event);
+        }
+
+        const kGalleryUrl = "chrome://conversations/content/gallery/index.html";
+
+        function galleryView(uri) {
+          let tabmail = topMail3Pane(window)
+            .document.getElementById("tabmail");
+          tabmail.openTab("chromeTab", {
+            chromePage: kGalleryUrl + "?uri=" + uri,
+          });
+        }
+
+        /**
+         * This function gathers various information, encodes it in a URL query
+         * string, and then opens a regular chrome tab that contains our
+         * conversation.
+         */
+        function detachTab(event) {
+          let tabmail = topMail3Pane(window)
+            .document.getElementById("tabmail");
+          let willExpand = $("textarea")
+            .parent()
+            .hasClass("expand") &&
+            startedEditing();
+          // Pick _initialSet and not msgHdrs so as to enforce the invariant
+          //  that the messages from _initialSet are in the current view.
+          let urls =
+            Conversations.currentConversation._initialSet.map(x => msgHdrGetUri(x))
+            .join(",");
+          let queryString = "?urls=" + encodeURIComponent(urls) +
+            "&willExpand=" + Number(willExpand);
+          // First, save the draft, and once it's saved, then move on to opening the
+          // conversation in a new tab...
+          onSave(function() {
+            openConversationInTabOrWindow(kStubUrl + queryString);
+          });
+        }
+
+        /**
+         * This function finds the right node that holds the attachment information
+         * and returns its information.
+         */
+        function getCurrentAttInfo() {
+          let node = topMail3Pane(window)
+            .document.popupNode;
+          while (!node.attInfo)
+            node = node.parentNode;
+          return node.attInfo;
+        }
+
+        /**
+         * That big event handler tries to parse URL query parameters, and then acts
+         * upon these, by firing a conversation on its own. This is a very
+         * stripped-down version of the logic that's in monkeypatch.js, and it
+         * serves the purpose of being able to create a standalone conversation view
+         * in a new tab.
+         */
+        $(document)
+        .ready(function() {
+          // I just imagined Javascript would have some function for that
+          // built-in... looks like even jQuery doesn't have it.
+          let params = decodeUrlParameters(document.location.href);
+
+          // Oh, are we expected to build a conversation on our own? Let's do it,
+          // yay!
+          if ("urls" in params) {
+            try {
+              let scrollMode = ("scrollMode" in params) ?
+                parseInt(params.scrollMode) :
+                Prefs.kScrollUnreadOrLast;
+              /* If we start up Thunderbird with a saved conversation tab, then we
+               * have no selected message. Fallback to the usual mode. */
+              if (scrollMode == Prefs.kScrollSelected &&
+                !topMail3Pane(window)
+                .gFolderDisplay.selectedMessage)
+                scrollMode = Prefs.kScrollUnreadOrLast;
+
+              isInTab = true;
+              if (window.frameElement)
+                window.frameElement.setAttribute("tooltip", "aHTMLTooltip");
+              let mainWindow = topMail3Pane(window);
+              let willExpand = parseInt(params.willExpand);
+              let msgHdrs = params.urls.split(",")
+                .map(x => msgUriToMsgHdr(x))
+                .filter(x => x != null && x.messageId);
+              // It might happen that there are no messages left...
+              if (!msgHdrs.length) {
+                document.getElementById("messageList")
+                  .textContent =
+                  strings.get("messageMovedOrDeletedConversation");
+              } else {
+                window.Conversations = {
+                  currentConversation: null,
+                  counter: 0,
+                };
+                let freshConversation = new mainWindow.Conversations.monkeyPatch._Conversation(
+                  window,
+                  msgHdrs,
+                  scrollMode,
+                  ++Conversations.counter
+                );
+                let browser = window.frameElement;
+                // Because Thunderbird still hasn't fixed that...
+                if (browser)
+                  browser.setAttribute("context", "mailContext");
+                freshConversation.outputInto(window, function(aConversation) {
+                  // This is a stripped-down version of what's in monkeypatch.js,
+                  //  make sure the two are in sync!
+                  Conversations.currentConversation = aConversation;
+                  aConversation.completed = true;
+                  registerQuickReply();
+                  // That's why we saved it before...
+                  newComposeSessionByDraftIf();
+                  if (willExpand)
+                    expandQuickReply();
+                  // Create a new rule that will override the default rule, so that
+                  // the expanded quick reply is twice higher.
+                  document.body.classList.add("inTab");
+                  // We can never junk a conversation in a new tab, because the junk
+                  // command only operates on selected messages, and we're not in a
+                  // 3pane context anymore.
+                  document.getElementById("conversationHeader")
+                    .classList.add(
+                      "not-junkable");
+                  // Do this now so as to not defeat the whole expand/collapse
+                  // logic.
+                  if (Prefs.getBool("mailnews.mark_message_read.auto")) {
+                    setTimeout(function() {
+                        msgHdrsMarkAsRead(msgHdrs, true);
+                      }, Prefs.getInt(
+                        "mailnews.mark_message_read.delay.interval") *
+                      Prefs.getBool("mailnews.mark_message_read.delay") *
+                      1000);
+                  }
+                });
+              }
+            } catch (e) {
+              Log.debug(e);
+              dumpCallStack(e);
+            }
+          } else if ("quickCompose" in params) {
+            masqueradeAsQuickCompose();
+          }
+        });
+
+        var isQuickCompose = false;
+
+        /* This is our new hack: reuse this file to provide a standalone composition
+         * window. Why? Because it uses gloda autocomplete and provides a
+         * no-frills composition experience. */
+        function masqueradeAsQuickCompose() {
+          isQuickCompose = true;
+          document.title = strings.get("write");
+          document.querySelector("#conversationHeader")
+            .style.display = "none";
+          document.querySelector(".bottom-links")
+            .style.display = "none";
+          document.querySelector("#messageList")
+            .style.marginTop = "0";
+          document.querySelector("#messageList")
+            .classList.add("quickCompose");
+          tmpl("#quickReplyTemplate")
+            .appendTo($("#messageList"));
+          $(".replyAll, #save, .replyMethod")
+            .remove();
+
+          // TODO figure out why this timeout is needed
+          setTimeout(function() {
+            showQuickReply.call($(".reply.expand"));
+            gComposeSession = createComposeSession(x => x.new());
+            revealCompositionFields();
+            editFields("to");
+          }, 0);
+
+          window.Conversations = {
+            currentConversation: {
+              msgHdrs: [],
+              id: null,
+            },
+          };
+
+          document.querySelector(".quickReply")
+            .addEventListener("keypress",
+              function(event) {
+                switch (event.keyCode) {
+                  case KeyEvent.DOM_VK_RETURN:
+                    if (isAccel(event)) {
+                      if (event.shiftKey)
+                        gComposeSession.send({
+                          archive: true
+                        });
+                      else
+                        gComposeSession.send();
+                    }
+                    break;
+                }
+              }, false);
+
+
+          let data = [];
+
+          // Push a new contact item in the list
+          let pushNewPopularContacts = function(n) {
+            let items = data.splice(0, n);
+            let nodes = tmpl("#popularContactTemplate", items);
+
+            items.forEach(function(data2, i) {
+              let data = data2;
+              let node = nodes.eq(i);
+              Log.debug("Adding", data.name, data.email);
+
+              node.find(".popularRemove")
+                .click(function() {
+                  Log.debug("Removing", data.name, data.email);
+                  // Mark it in the prefs
+                  let unwantedRecipients = JSON.parse(Prefs.getString(
+                    "conversations.unwanted_recipients"));
+                  unwantedRecipients[data.email] = null;
+                  Prefs.setString("conversations.unwanted_recipients",
+                    JSON.stringify(unwantedRecipients));
+                  // Update the UI
+                  $(this)
+                    .closest(".popularContact")
+                    .remove();
+                  pushNewPopularContacts(1);
+                });
+
+              node.find(".popularName")
+                .click(function() {
+                  // Get all the current parameters
+                  let to = JSON.parse($("#to")
+                    .val());
+                  let cc = JSON.parse($("#cc")
+                    .val());
+                  let bcc = JSON.parse($("#bcc")
+                    .val());
+                  // Append our new value
+                  to.push(MailServices.headerParser.makeMimeAddress(data.name,
+                    data.email));
+                  // Re-set everything
+                  let format = items => items.map(parseMimeLine)
+                    .map(([{
+                      name,
+                      email
+                    }]) => asToken(null, name, email, null));
+                  setupAutocomplete(format(to), format(cc), format(bcc));
+                  // Remove the node!
+                  node.remove();
+                  pushNewPopularContacts(1);
+                });
+
+            });
+
+            nodes.appendTo($(".quickReplyContactsBox"));
+          };
+
+          $(".quickReplyContactsMoreLink")
+            .click(() => pushNewPopularContacts(10));
+
+          // Fill in the "10 most popular contacts" thing
+          let contactQuery = Gloda.newQuery(Gloda.NOUN_CONTACT);
+          contactQuery.orderBy("-popularity")
+            .limit(100);
+          let contactCollection = contactQuery.getCollection({
+            onItemsAdded: function(aItems, aCollection) {},
+            onItemsModified: function(aItems, aCollection) {},
+            onItemsRemoved: function(aItems, aCollection) {},
+            onQueryCompleted: function(aCollection) {
+              let items = aCollection.items;
+              let unwantedRecipients = JSON.parse(Prefs.getString(
+                "conversations.unwanted_recipients"));
+
+              for (let contact of items) {
+                if (contact.identities.length) {
+                  let id = contact.identities[0];
+                  let photoForAbCard = function(card) {
+                    if (!card)
+                      return defaultPhotoURI;
+                    let url = card.getProperty("PhotoURI", "");
+                    if (!url)
+                      return defaultPhotoURI;
+                    return url;
+                  };
+                  if (id.kind == "email" && !(id.value in unwantedRecipients)) {
+                    // Log.debug("Pushing", id.value, contact.name, contact.popularity);
+                    data.push({
+                      email: id.value,
+                      name: contact.name,
+                      photo: photoForAbCard(id.abCard),
+                    });
+                  }
+                }
+              }
+
+              pushNewPopularContacts(10);
+            },
+          }, null);
+          contactCollection.becomeExplicit();
+
+          // Misc
+          if (!top.opener) {
+            window.frameElement.setAttribute("tooltip", "aHTMLTooltip");
+            window.frameElement.setAttribute("context", "mailContext");
+          }
+        }
+
+        // Mark a message as read if a user scrolls past top and bottom of an
+        // unread message.
+        function markReadInView(event) {
+          if (event.type == "keydown") {
+            // for scroll by keyboard shortcut
+            switch (event.which) {
+              case KeyEvent.DOM_VK_SPACE:
+              case KeyEvent.DOM_VK_TAB:
+              case KeyEvent.DOM_VK_PAGE_UP:
+              case KeyEvent.DOM_VK_PAGE_DOWN:
+              case KeyEvent.DOM_VK_UP:
+              case KeyEvent.DOM_VK_DOWN:
+              case KeyEvent.DOM_VK_F:
+              case KeyEvent.DOM_VK_B:
+                break;
+              default:
+                return;
+            }
+          }
+          document.removeEventListener("scroll", markReadInView, true);
+          clearTimeout(markReadInView.timeout);
+          markReadInView.timeout = setTimeout(function() {
+            document.addEventListener("scroll", markReadInView, true);
+          }, 200);
+          if (!Conversations.currentConversation)
             return;
+
+          let pageTop = window.pageYOffset;
+          let pageBottom = pageTop + window.innerHeight;
+          let messages = Conversations.currentConversation.messages;
+          messages.forEach(function({
+            message
+          }, i) {
+            if (!message.read && message.expanded) {
+              if (!message._topInView) {
+                let top = $(message._domNode)
+                  .offset()
+                  .top;
+                if (top > pageTop && top < pageBottom)
+                  message._topInView = true;
+              }
+              if (!message._bottomInView) {
+                let footerClass = (i == messages.length - 1) ? ".quickReply" :
+                  ".messageFooter";
+                let bottom = $(message._domNode.querySelector(footerClass))
+                  .offset()
+                  .top;
+                if (bottom > pageTop && bottom < pageBottom)
+                  message._bottomInView = true;
+              }
+              if (message._topInView && message._bottomInView) {
+                message._topInView = false;
+                message._bottomInView = false;
+                message.read = true;
+              }
+            }
+          });
         }
-      }
-      document.removeEventListener("scroll", markReadInView, true);
-      clearTimeout(markReadInView.timeout);
-      markReadInView.timeout = setTimeout(function () {
-        document.addEventListener("scroll", markReadInView, true);
-      }, 200);
-      if (!Conversations.currentConversation)
-        return;
+        (function() {
+          let w = window;
+          markReadInView.enable = function() {
+            for (let x of["mouseover", "focus", "keydown"]) {
+              w.document.addEventListener(x, w.markReadInView, true);
+            }
+          };
+          markReadInView.disable = function() {
+            w.clearTimeout(w.markReadInView.timeout);
+            for (let x of["mouseover", "focus", "keydown", "scroll"]) {
+              w.document.removeEventListener(x, w.markReadInView, true);
+            }
+          };
+        })();
 
-      let pageTop = window.pageYOffset;
-      let pageBottom = pageTop + window.innerHeight;
-      let messages = Conversations.currentConversation.messages;
-      messages.forEach(function({ message }, i) {
-        if (!message.read && message.expanded) {
-          if (!message._topInView) {
-            let top = $(message._domNode).offset().top;
-            if (top > pageTop && top < pageBottom)
-              message._topInView = true;
-          }
-          if (!message._bottomInView) {
-            let footerClass = (i == messages.length - 1) ? ".quickReply" : ".messageFooter";
-            let bottom = $(message._domNode.querySelector(footerClass)).offset().top;
-            if (bottom > pageTop && bottom < pageBottom)
-              message._bottomInView = true;
-          }
-          if (message._topInView && message._bottomInView) {
-            message._topInView = false;
-            message._bottomInView = false;
-            message.read = true;
-          }
-        }
-      });
-    }
-    (function () {
-      let w = window;
-      markReadInView.enable = function () {
-        for (let x of ["mouseover", "focus", "keydown"]) {
-          w.document.addEventListener(x, w.markReadInView, true);
-        }
-      };
-      markReadInView.disable = function () {
-        w.clearTimeout(w.markReadInView.timeout);
-        for (let x of ["mouseover", "focus", "keydown", "scroll"]) {
-          w.document.removeEventListener(x, w.markReadInView, true);
-        }
-      };
-    })();
+        // Lightning
+        var ltnImipBar = topMail3Pane(window)
+          .ltnImipBar;
+      ]]>
+    </script>
+  </head>
 
-    // Lightning
-    var ltnImipBar = topMail3Pane(window).ltnImipBar;
-  ]]>
-  </script>
-</head>
+  <body>
+    <menu id="attachmentMenu" type="context">
+      <menuitem label="&stub.context.open;" onclick="getCurrentAttInfo().open();"></menuitem>
+      <menuitem label="&stub.context.save;" onclick="getCurrentAttInfo().save();"></menuitem>
+      <menuitem label="&stub.context.detach;" onclick="getCurrentAttInfo().detach(true);"></menuitem>
+      <menuitem label="&stub.context.delete;" onclick="getCurrentAttInfo().detach(false);"></menuitem>
+    </menu>
+    <script id="detailsTemplate" type="text/x-handlebars-template">
+      <![CDATA[
 
-<body>
-  <menu id="attachmentMenu" type="context">
-    <menuitem label="&stub.context.open;" onclick="getCurrentAttInfo().open();"></menuitem>
-    <menuitem label="&stub.context.save;" onclick="getCurrentAttInfo().save();"></menuitem>
-    <menuitem label="&stub.context.detach;" onclick="getCurrentAttInfo().detach(true);"></menuitem>
-    <menuitem label="&stub.context.delete;" onclick="getCurrentAttInfo().detach(false);"></menuitem>
-  </menu>
-  <script id="detailsTemplate" type="text/x-handlebars-template"><![CDATA[
-      {{#if dataContactsFrom.length}}
-        <div class="detailsLine fromLine">
-          <u>{{str "fieldFrom"}}</u>
-          {{tmpl "contact" dataContactsFrom}}
-        </div>
-      {{/if}}
-      {{#if dataContactsTo.length}}
-        <div class="detailsLine toLine">
-          <u>{{str "fieldTo"}}</u>
-          {{tmpl "contact" dataContactsTo}}
-        </div>
-      {{/if}}
-      {{#if dataContactsCc.length}}
-        <div class="detailsLine ccLine">
-          <u>{{str "fieldCc"}}</u>
-          {{tmpl "contact" dataContactsCc}}
-        </div>
-      {{/if}}
-      {{#if dataContactsBcc.length}}
-        <div class="detailsLine bccLine">
-          <u>{{str "fieldBcc"}}</u>
-          {{tmpl "contact" dataContactsBcc}}
-        </div>
-      {{/if}}
-      {{#each extraLines}}
-        <div class="detailsLine">
-          <u>{{key}}:</u>
-          {{value}}
-        </div>
-      {{/each}}
-    ]]>
-  </script>
-  <script id="messageTemplate" type="text/x-handlebars-template"><![CDATA[
-    <li class="message collapsed {{extraClasses}}">
-      <div class="messageHeader hbox">
-        <div class="shrink-box">
-          <div class="star"><svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="chrome://conversations/skin/material-icons.svg#star"></use></svg></div>
-          <span class="author">{{tmpl "contactLabel" dataContactFrom}}</span>
-          <span class="to hide-with-details"> {{str "to"}} {{tmpl "contactLabel" dataContactsTo}}</span>
-          <span class="recipient-tooltips">{{tmpl "contactTooltip" dataContactFrom}}{{tmpl "contactTooltip" dataContactsTo}}</span>
-          <span class="bzTo"> {{str "at"}} {{bugzillaUrl}}</span>
-          <span class="snippet"><ul class="tags regular-tags"></ul><ul
-              class="tags special-tags"
-            ><li
-              class="tag-signed"
-              title="{{str 'messageSignedLong'}}"
-              ><svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="chrome://conversations/skin/material-icons.svg#edit"></use></svg>
-              {{str "messageSigned"}}</li
-            ><li
-              class="tag-decrypted"
-              title="{{str 'messageDecryptedLong'}}"
-              ><svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="chrome://conversations/skin/material-icons.svg#vpn_key"></use></svg>
-              {{str "messageDecrypted"}}</li
-            ><li
-              class="tag-dkim-signed"
-              ><svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="chrome://conversations/skin/material-icons.svg#edit"></use></svg>
-              {{str "messageDKIMSigned"}}</li
-            ><li
-              class="in-folder"
-              title="{{str 'jumpToFolder'}}"
-              >{{str "inFolder" shortFolderName}}</li
-            ></ul>{{snippet}}</span>
-        </div>
-        <div class="options">
-          <span class="attachmentIcon">
-            {{tmpl "attachmentIcon" this}}
-          </span>
-          <span class="date">
-            <span title="{{fullDate}}">{{date}}</span>
-          </span>
-          <span class="details hide-with-details">
-            | <a href="javascript:" class="link">{{str "details"}}</a>
-          </span>
-          <span class="hide-details show-with-details">
-            | <a href="javascript:" class="link">{{str "hideDetails"}}</a>
-          </span>
-          <span class="replyLinkWrapper">
-            | <a href="javascript:" class="link replyMainActionLink"></a>
-          </span>
-          <span class="editDraftLinkWrapper">
-            | <a href="javascript:" class="link edit-draft">{{str "editDraft2"}}</a>
-          </span>
-          <span class="dropDown"> |
-            <a href="javascript:" onclick="displayMenu(event);" class="link top-right-more">{{str "more"}} <span class="downwardArrow">&#x25bc;</span></a>
-            <div class="tooltip tooltip-menu menu">
-              <ul>
-                <li class="action-reply">
-                  <!-- arow should change color along with first item on hover -->
-                  <div class="arrow"></div>
-                  <div class="arrow inside"></div>
-
-                  <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="chrome://conversations/skin/material-icons.svg#reply"></use></svg> {{str "reply"}}
-                </li>
-                <li class="action-replyAll"><svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="chrome://conversations/skin/material-icons.svg#reply_all"></use></svg> {{str "replyAll"}}</li>
-                <li class="action-replyList"><svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="chrome://conversations/skin/material-icons.svg#list"></use></svg> {{str "replyList"}}</li>
-                <li class="action-editNew"><svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="chrome://conversations/skin/material-icons.svg#edit"></use></svg> {{str "editNew"}}</li>
-                <li class="action-forward dropdown-sep"><svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="chrome://conversations/skin/material-icons.svg#forward"></use></svg> {{str "forward"}}</li>
-                <li class="action-archive"><svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="chrome://conversations/skin/material-icons.svg#archive"></use></svg> {{str "archive"}}</li>
-                <li class="action-delete"><svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="chrome://conversations/skin/material-icons.svg#delete"></use></svg> {{str "delete"}}</li>
-                <li class="action-classic"><svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="chrome://conversations/skin/material-icons.svg#open_in_new"></use></svg> {{str "viewClassic"}}</li>
-                <li class="action-source"><svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="chrome://conversations/skin/material-icons.svg#code"></use></svg> {{str "viewSource"}}</li>
-                <li class="action-print" style="display: none;"><svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="chrome://conversations/skin/material-icons.svg#print"></use></svg> {{str "print"}}</li>
-              </ul>
-            </div>
-          </span>
-        </div>
-      </div>
-      <div class="detailsPlaceholder show-with-details">
-      </div>
-      <div class="detailsLine">
-        {{tmpl "attachmentDetails" this}}
-      </div>
-
-      {{#if generateLightningTempl}}
-      <div class="lightningImipBar notificationBar" style="display: none">
-        <img class="lightningImipImage" src="chrome://calendar/skin/cal-icon32.png"/>
-        <span class="lightningImipText"></span>
-        <!-- The text for all these buttons is filled dynamically -->
-
-        <!-- show event/invitation details -->
-        <button id="imipDetailsButton"
-                class="lightningImipButton msgHeaderView-button imipDetailsButton"
-                onclick="ltnImipBar.executeAction('X-SHOWDETAILS')"
-                style="display: none">
-        </button>
-
-        <!-- add published events -->
-        <button id="imipAddButton"
-                class="lightningImipButton msgHeaderView-button imipAddButton"
-                onclick="ltnImipBar.executeAction()"
-                style="display: none">
-        </button>
-
-        <!-- update published events and invitations -->
-        <button id="imipUpdateButton"
-                class="lightningImipButton msgHeaderView-button imipUpdateButton"
-                onclick="ltnImipBar.executeAction()"
-                style="display: none">
-        </button>
-
-        <!-- delete cancelled events from calendar -->
-        <button id="imipDeleteButton"
-                class="lightningImipButton msgHeaderView-button imipDeleteButton"
-                onclick="ltnImipBar.executeAction()"
-                style="display: none">
-        </button>
-
-        <!-- re-confirm partstat -->
-        <button id="imipReconfirmButton"
-                class="lightningImipButton msgHeaderView-button imipReconfirmButton"
-                onclick="ltnImipBar.executeAction()"
-                style="display: none">
-        </button>
-
-        <!-- accept -->
-        <button id="imipAcceptButton"
-                onclick="if (event.target.id == this.id) ltnImipBar.executeAction('ACCEPTED');"
-                type="menu-button"
-                class="imip-button lightningImipButton msgHeaderView-button imipAcceptButton"
-                style="display: none">
-          <menupopup id="imipAcceptDropdown">
-            <menuitem id="imipAcceptButton_Accept"
-                      onclick="ltnImipBar.executeAction('ACCEPTED');"/>
-            <menuitem id="imipAcceptButton_Tentative"
-                      onclick="ltnImipBar.executeAction('TENTATIVE');"/>
-            <!-- add here more menuitem as needed -->
-          </menupopup>
-        </button>
-
-        <!-- accept recurrences -->
-        <button id="imipAcceptRecurrencesButton"
-                onclick="if (event.target.id == this.id) ltnImipBar.executeAction('ACCEPTED');"
-                type="menu-button"
-                class="imip-button lightningImipButton msgHeaderView-button imipAcceptRecurrencesButton"
-                style="display: none">
-          <menupopup id="imipAcceptRecurrencesDropdown">
-            <menuitem id="imipAcceptRecurrencesButton_Accept"
-                      onclick="ltnImipBar.executeAction('ACCEPTED');"/>
-            <menuitem id="imipAcceptRecurrencesButton_Tentative"
-                      onclick="ltnImipBar.executeAction('TENTATIVE');"/>
-            <!-- add here more menuitem as needed -->
-          </menupopup>
-        </button>
-
-        <!-- tentative; should only be used, if no imipMoreButton is used and
-           - imipDeclineButton/imipAcceptButton have no visible menuitems //-->
-        <button id="imipTentativeButton"
-                class="lightningImipButton msgHeaderView-button imipTentativeButton"
-                onclick="if (event.target.id == this.id) ltnImipBar.executeAction('TENTATIVE');"
-                type="menu-button"
-                style="display: none">
-          <menupopup id="imipTentativeDropdown">
-            <menuitem id="imipTentativeButton_Tentative"
-                      onclick="ltnImipBar.executeAction('TENTATIVE');"/>
-            <!-- add here more menuitem as needed -->
-          </menupopup>
-        </button>
-
-        <!-- tentative recurrences; should only be used, if no imipMoreButton is used and
-           - imipDeclineRecurrencesButton/imipAcceptRecurrencesButton have no visible menuitems //-->
-        <button id="imipTentativeRecurrencesButton"
-                class="lightningImipButton msgHeaderView-button imipTentativeRecurrencesButton"
-                onclick="if (event.target.id == this.id) ltnImipBar.executeAction('TENTATIVE');"
-                type="menu-button"
-                style="display: none">
-          <menupopup id="imipTentativeRecurrencesDropdown">
-            <menuitem id="imipTentativeRecurrencesButton_Tentative"
-                      onclick="ltnImipBar.executeAction('TENTATIVE');"/>
-            <!-- add here more menuitem as needed -->
-          </menupopup>
-        </button>
-
-        <!-- decline -->
-        <button id="imipDeclineButton"
-                onclick="if (event.target.id == this.id) ltnImipBar.executeAction('DECLINED');"
-                type="menu-button"
-                class="lightningImipButton msgHeaderView-button imipDeclineButton"
-                style="display: none">
-          <menupopup id="imipDeclineDropdown">
-            <menuitem id="imipDeclineButton_Decline"
-                      onclick="ltnImipBar.executeAction('DECLINED');"/>
-            <!-- add here more menuitem as needed -->
-          </menupopup>
-        </button>
-
-        <!-- decline recurrences -->
-        <button id="imipDeclineRecurrencesButton"
-                onclick="if (event.target.id == this.id) ltnImipBar.executeAction('DECLINED');"
-                type="menu-button"
-                class="lightningImipButton msgHeaderView-button imipDeclineRecurrencesButton"
-                style="display: none">
-          <menupopup id="imipDeclineRecurrencesDropdown">
-            <menuitem id="imipDeclineRecurrencesButton_DeclineAll"
-                      onclick="ltnImipBar.executeAction('DECLINED');"/>
-            <!-- add here more menuitem as needed -->
-          </menupopup>
-        </button>
-
-        <!-- more options -->
-        <button id="imipMoreButton"
-                type="menu"
-                class="lightningImipButton msgHeaderView-button imipMoreButton"
-                style="display: none">
-          <menupopup id="imipMoreDropdown">
-            <!-- add here a menuitem as needed -->
-          </menupopup>
-        </button>
-      </div>
-      {{/if}}
-      <div class="phishingBar notificationBar" style="display: none">
-        <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="chrome://conversations/skin/material-icons.svg#warning"></use></svg>
-        {{str "scam"}}
-        <span class="ignore-warning">
-          <a href="javascript:">{{str "ignoreWarning"}}</a>
-        </span>
-      </div>
-      <div class="remoteContent notificationBar" style="display: none">
-        {{str "remoteContentBlocked"}}
-        <span class="show-remote-content">
-          <a href="javascript:">{{str "showRemote"}}</a> -
-        </span>
-        <span class="always-display">
-          <a href="javascript:">{{str "alwaysShowRemote" realFrom}}</a>
-        </span>
-      </div>
-      <div class="junkBar notificationBar" {{#unless canUnJunk}}style="display: none"{{/unless}}>
-        <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="chrome://conversations/skin/material-icons.svg#whatshot"></use></svg>
-        {{str "junk"}}
-        <span class="notJunk">
-          <a href="javascript:">{{str "notJunk"}}</a>
-        </span>
-      </div>
-      <div class="outboxBar notificationBar" {{#unless isOutbox}}style="display: none"{{/unless}}>
-        <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="chrome://conversations/skin/material-icons.svg#inbox"></use></svg>
-        {{str "isOutbox"}}
-        <span class="sendUnsent">
-          <a href="javascript:">{{str "sendUnsent"}}</a>
-        </span>
-      </div>
-      <div class="enigmailBar notificationBar" style="display: none">
-        <span class="enigmailMessage"></span>
-        <span class="enigmailDetails">
-          <button>{{str "Details"}}</button>
-        </span>
-      </div>
-
-      <div class="messageBody">
-        <!-- Weird markup to deal with whitespace DOM nodes -->
-        <ul class="tags special-tags"
-          ><li
-            class="keep-tag tag-signed"
-            title="{{str 'messageSignedLong'}}"
-            ><svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="chrome://conversations/skin/material-icons.svg#edit"></use></svg>
-            {{str "messageSigned"}}</li
-          ><li
-            class="keep-tag tag-decrypted"
-            title="{{str 'messageDecryptedLong'}}"
-            ><svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="chrome://conversations/skin/material-icons.svg#vpn_key"></use></svg>
-            {{str "messageDecrypted"}}</li
-          ><li
-            class="keep-tag tag-dkim-signed"
-            ><svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="chrome://conversations/skin/material-icons.svg#edit"></use></svg>
-            {{str "messageDKIMSigned"}}</li
-          ><li
-            class="keep-tag in-folder"
-            title="{{str 'jumpToFolder'}}"
-            >{{str "inFolder" folderName}}</li
-          ></ul
-        >
-        <ul class="tags regular-tags"></ul>
-        <div class="iframe-container"></div>
-        <div class="body-container"></div>
-        <div class="attachments-container">
-          {{tmpl "attachments" this}}
-        </div>
-        <div class="embedsContainer">
-        </div>
-      </div>
-      <div class="messageFooter">
-        <div class="footerActions">
-          <button class="edit-draft" title="{{str 'editDraft2'}}"><svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="chrome://conversations/skin/material-icons.svg#edit"></use></svg></button>
-          <button class="buttonReply" title="{{str 'reply'}}"><svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="chrome://conversations/skin/material-icons.svg#reply"></use></svg> <span></span></button>
-          <button class="buttonReplyAll" title="{{str 'replyAll'}}"><svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="chrome://conversations/skin/material-icons.svg#reply_all"></use></svg></button>
-          <button class="buttonReplyList" title="{{str 'replyList'}}"><svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="chrome://conversations/skin/material-icons.svg#list"></use></svg></button>
-          <button class="buttonForward" title="{{str 'forward'}}"><svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="chrome://conversations/skin/material-icons.svg#forward"></use></svg></button>
-        </div>
-      </div>
-      {{#if quickReply}}
-        {{tmpl "quickReply" this}}
-      {{/if}}
-    </li>
-    ]]>
-  </script>
-  <!-- Weird markup again, otherwise, the comma is separated from the name by a
-    space because of the #text whitespace-only nodes that end up in the DOM.
-  -->
-  <!-- Generic contact template with tooltip -->
-  <script id="contactTemplate" type="text/x-handlebars-template"><![CDATA[
-    {{tmpl "contactLabel" this}}{{tmpl "contactTooltip" this}}
-  ]]></script>
-  <!-- Contact template specific to recipients, without tooltip -->
-  <script id="contactLabelTemplate" type="text/x-handlebars-template"><![CDATA[<span
-    >{{separator}}</span
-    ><span class="tooltipWrapper contact"
-      ><span class="contactName" style="{{colorStyle}}"
-        >{{#if star}}&#x2605; {{/if}}{{trim name}}{{#if extra}}
-        <label xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
-          crop="center" class="contactExtra"
-          value="({{extra}})"
-        />{{/if}}{{#if displayEmail}}<span class="smallEmail"
-          > &lt;{{trim displayEmail}}&gt;</span>{{/if}}{{#if writeBr}}<br />{{/if}}</span
-      ></span
-  >]]></script>
-  <!-- Tooltip template specific to recipients -->
-  <script id="contactTooltipTemplate" type="text/x-handlebars-template"><![CDATA[<span
-    class="contactTooltipWrapper contact">{{tmpl "innerTooltip" this}}</span
-  >]]></script>
-  <!-- Inner tooltip template, to be used by other templates. Currently only used by the template above. -->
-  <script id="innerTooltipTemplate" type="text/x-handlebars-template"><![CDATA[<div
-    class="tooltip">
-      <div class="arrow"></div>
-      <div class="arrow inside"></div>
-      <div class="authorInfoContainer">
-        <div class="authorInfo">
-          <span class="name" title="{{tooltipName}}">{{tooltipName}}</span>
-          <span class="authorEmail">
-            <span class="authorEmailAddress" title="{{email}}">{{email}}</span>
-            <button class="copyEmail" title="{{str 'copyEmail'}}">
-              <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="chrome://conversations/skin/material-icons.svg#content_copy"></use></svg>
-            </button>
-          </span>
-        </div>
-        <div class="authorPicture">
-          <img src="{{avatar}}" />
-        </div>
-      </div>
-      <div class="tipFooter hiddenFooter" style="display:none;">
-        {{#if showMonospace}}
-        <div style="margin-bottom:5px;">
-          <input type="checkbox" style="vertical-align: text-top" class="checkbox-monospace" />
-          <label style="color:#666; font-weight: normal">{{str "messagesMonospace"}}</label>
-        </div>
+        {{#if dataContactsFrom.length}}
+          <div class="detailsLine fromLine">
+            <u>{{str "fieldFrom"}}</u>
+            {{tmpl "contact" dataContactsFrom}}
+          </div>
         {{/if}}
-        <button class="createFilter">{{str "createFilter"}}</button>
-        <button class="addContact" title="{{str 'addToAb'}}">
-          <img src="chrome://conversations/content/i/user_add.png" />
-        </button>
-        <button class="editContact" title="{{str 'editCardAb'}}">
-          <img src="chrome://conversations/content/i/user_edit.png" />
-        </button>
-      </div>
-      <div class="tipFooter">
-        <button class="sendEmail">{{str "sendEmail"}}</button>
-        <button class="showInvolving">{{str "recentConversations"}}</button>
-        <button class="moreExpander">+</button>
-      </div>
-    </div
-  >]]></script>
-  <script id="attachmentIconTemplate" type="text/x-handlebars-template"><![CDATA[
-    {{#if attachments.length}}
-      <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="chrome://conversations/skin/material-icons.svg#attachment"></use></svg>
-    {{/if}}
-  ]]></script>
-  <script id="attachmentDetailsTemplate" type="text/x-handlebars-template"><![CDATA[
-    {{#if attachments.length}}
-      <u>{{attachmentsPlural}}:</u>
-      {{#each attachments}}
-        <a href="javascript:"
-          onclick="scrollNodeIntoView(document.getElementById('{{anchor}}'));">
-          {{name}} ({{formattedSize}})</a>{{sep}}
-      {{/each}}
-    {{/if}}
-  ]]></script>
-  <script id="attachmentsTemplate" type="text/x-handlebars-template"><![CDATA[
-    {{#if attachments.length}}
-      <ul class="attachments">
-        <div class="attachHeader">
-          {{attachmentsPlural}}
-          | <a href="javascript:" class="link download-all">{{str "downloadAll2"}}</a>
-          {{#if gallery}}
-          | <a href="javascript:" onclick="galleryView('{{uri}}')" class="link view-all">
-              {{str "galleryView"}}
-            </a>
-          {{/if}}
-        </div>
-        {{#each attachments}}
-        <li class="clearfix hbox attachment" draggable="true" id="{{anchor}}">
-          <div class="attachmentThumb">
-            <img onload="$(this).closest('.attachment').find('.align').vAlign()"
-            class="{{imgClass}}" src="{{thumb}}" />
+
+        {{#if dataContactsTo.length}}
+          <div class="detailsLine toLine">
+            <u>{{str "fieldTo"}}</u>
+            {{tmpl "contact" dataContactsTo}}
           </div>
-          <div class="attachmentInfo align">
-            <span class="filename">{{name}}</span>
-            <div class="attachActions">
-              {{formattedSize}}
-              {{#if canPreview}}
-              | <a href="javascript:" class="link preview-attachment">{{str "preview"}}</a>
-              {{/if}}
-              | <a href="javascript:" class="link open-attachment">{{str "open"}}</a>
-              | <a href="javascript:" class="link download-attachment">{{str "download2"}}</a>
-            </div>
+        {{/if}}
+
+        {{#if dataContactsCc.length}}
+          <div class="detailsLine ccLine">
+            <u>{{str "fieldCc"}}</u>
+            {{tmpl "contact" dataContactsCc}}
           </div>
-        </li>
+        {{/if}}
+
+        {{#if dataContactsBcc.length}}
+          <div class="detailsLine bccLine">
+            <u>{{str "fieldBcc"}}</u>
+            {{tmpl "contact" dataContactsBcc}}
+          </div>
+        {{/if}}
+
+        {{#each extraLines}}
+          <div class="detailsLine">
+            <u>{{key}}:</u>
+            {{value}}
+          </div>
         {{/each}}
-      </ul>
-    {{/if}}
-  ]]></script>
-  <script id="popularContactTemplate" type="text/x-handlebars-template"><![CDATA[
-    <div class="popularContact">
-      <img class="popularPhoto" src="{{photo}}" style="float: left" />
-      <span class="popularRemove">×</span>
-      <span class="popularName">{{name}}</span><br />
-      <span class="popularEmail">{{email}}</span>
-    </div>
-  ]]></script>
-  <script id="quickReplyTemplate" type="text/x-handlebars-template"><![CDATA[
-    <div class="quickReply" ondragover="quickReplyCheckDrag(event);" ondrop="quickReplyDrop(event);">
-      <div class="quickReplyContacts">
-        <div class="quickReplyContactsHeader">
-          {{str "mostFrequentContacts"}}
-        </div>
-        <div class="quickReplyContactsBox">
-        </div>
-        <div class="quickReplyContactsMore">
-          <a class="quickReplyContactsMoreLink">
-            {{str "showMore"}}
-          </a>
-        </div>
-      </div>
-      <div class="quickReplyBox">
-        <div class="replyHeader">
-          <div class="quickReplyRecipients">
-            <ul class="fromField">
-              {{str "fieldFrom"}}
-              <li class="senderSwitcher"><a class="switchLeft" onclick="gComposeSession.cycleSender(-1)">◂</a> <a class="switchRight" onclick="gComposeSession.cycleSender(1)">▸</a></li>
-              <li class="senderName"></li>,
-              <li class="replyMethod">
-                <input type="radio" name="reply-method" value="reply"
-                  onchange="changeComposeFields('reply')" id="reply-radio"
-                /><label for="reply-radio">{{str "reply"}}</label>
-              </li>
-              <li class="replyMethod replyMethod-replyAll">
-                <input type="radio" name="reply-method" value="replyAll"
-                  onchange="changeComposeFields('replyAll')" id="replyAll-radio"
-                /><label for="replyAll-radio">{{str "replyAll"}}</label>
-              </li>
-              <li class="replyMethod replyMethod-replyList">
-                <input type="radio" name="reply-method" value="replyList"
-                  onchange="changeComposeFields('replyList')" id="replyList-radio"
-                /><label for="replyList-radio">{{str "replyList"}}</label>
-              </li>
-              <li class="replyMethod">
-                <input type="radio" name="reply-method" value="forward"
-                  onchange="changeComposeFields('forward')" id="forward-radio"
-                /><label for="forward-radio">{{str "forward"}}</label>
-              </li>
-              <li class="firstBar">|</li>
-              <li class="showCc"><a onclick="showCc(); editFields('cc');" href="javascript:">{{str "addCc"}}</a> |</li>
-              <li class="showBcc"><a onclick="showBcc(); editFields('bcc');" href="javascript:">{{str "addBcc"}}</a> |</li>
-              <li class="addAttachment"><a onclick="addAttachment();" href="javascript:">{{str "addAttachment"}}</a></li>
-            </ul>
-            <div class="editRecipientList editToList hbox">
-              <div class="label">{{str "fieldTo"}}</div>
-              <div class="boxFlex"><input type="text" id="to" /></div>
+
+      ]]>
+    </script>
+
+    <script id="messageTemplate" type="text/x-handlebars-template">
+      <![CDATA[
+        <li class="message collapsed {{extraClasses}}">
+          <div class="messageHeader hbox">
+            <div class="shrink-box">
+              <div class="star">
+              <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <use xlink:href="chrome://conversations/skin/material-icons.svg#star"></use>
+              </svg>
+              </div>
+              <span class="author">{{tmpl "contactLabel" dataContactFrom}}</span>
+              <span class="to hide-with-details"> {{str "to"}} {{tmpl "contactLabel" dataContactsTo}}</span>
+              <span class="recipient-tooltips">{{tmpl "contactTooltip" dataContactFrom}}{{tmpl "contactTooltip" dataContactsTo}}</span>
+              <span class="bzTo"> {{str "at"}} {{bugzillaUrl}}</span>
+              <div class="snippet">
+                <ul class="tags regular-tags"></ul><ul
+                    class="tags special-tags">
+                  <li class="tag-signed"
+                    title="{{str 'messageSignedLong'}}">
+                    <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                      <use xlink:href="chrome://conversations/skin/material-icons.svg#edit"></use>
+                    </svg>
+                    {{str "messageSigned"}}
+                  </li>
+                  <li class="tag-decrypted"
+                    title="{{str 'messageDecryptedLong'}}">
+                    <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                      <use xlink:href="chrome://conversations/skin/material-icons.svg#vpn_key"></use>
+                    </svg>
+                    {{str "messageDecrypted"}}
+                  </li>
+                  <li class="tag-dkim-signed">
+                    <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                      <use xlink:href="chrome://conversations/skin/material-icons.svg#edit"></use>
+                    </svg>
+                    {{str "messageDKIMSigned"}}
+                  </li>
+                  <li class="in-folder"
+                    title="{{str 'jumpToFolder'}}">{{str "inFolder" shortFolderName}}</li>
+                </ul>
+                {{snippet}}
+              </div>
             </div>
-            <div class="editRecipientList editCcList hbox" style="display: none">
-              <div class="label">{{str "fieldCc"}}</div>
-              <div class="boxFlex"><input type="text" id="cc" /></div>
+            <div class="options">
+              <span class="attachmentIcon">
+                {{tmpl "attachmentIcon" this}}
+              </span>
+              <span class="date">
+                <span title="{{fullDate}}">{{date}}</span>
+              </span>
+              <span class="details hide-with-details">
+                | <a href="javascript:" class="link">
+     {{str "details"}}
+   </a>
+              </span>
+              <span class="hide-details show-with-details">
+                | <a href="javascript:" class="link">
+     {{str "hideDetails"}}
+   </a>
+              </span>
+              <span class="replyLinkWrapper">
+                | <a href="javascript:" class="link replyMainActionLink"></a>
+              </span>
+              <span class="editDraftLinkWrapper">
+                | <a href="javascript:" class="link edit-draft">
+     {{str "editDraft2"}}
+   </a>
+              </span>
+              <span class="dropDown"> |
+                <a href="javascript:" onclick="displayMenu(event);" class="link top-right-more">
+                  {{str "more"}}
+                  <span class="downwardArrow">&#x25bc;</span>
+                </a>
+                <div class="tooltip tooltip-menu menu">
+                  <ul>
+                    <li class="action-reply">
+                      <!-- arow should change color along with first item on hover -->
+                      <div class="arrow"></div>
+                      <div class="arrow inside"></div>
+                      <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                        <use xlink:href="chrome://conversations/skin/material-icons.svg#reply"></use>
+                      </svg> {{str "reply"}}
+                    </li>
+                    <li class="action-replyAll">
+                    <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                      <use xlink:href="chrome://conversations/skin/material-icons.svg#reply_all"></use>
+                    </svg> {{str "replyAll"}}</li>
+                    <li class="action-replyList">
+                    <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                      <use xlink:href="chrome://conversations/skin/material-icons.svg#list"></use>
+                    </svg> {{str "replyList"}}</li>
+                    <li class="action-editNew">
+                    <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                      <use xlink:href="chrome://conversations/skin/material-icons.svg#edit"></use>
+                    </svg> {{str "editNew"}}</li>
+                    <li class="action-forward dropdown-sep">
+                    <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                      <use xlink:href="chrome://conversations/skin/material-icons.svg#forward"></use>
+                    </svg> {{str "forward"}}</li>
+                    <li class="action-archive">
+                    <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                      <use xlink:href="chrome://conversations/skin/material-icons.svg#archive"></use>
+                    </svg> {{str "archive"}}</li>
+                    <li class="action-delete">
+                    <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                      <use xlink:href="chrome://conversations/skin/material-icons.svg#delete"></use>
+                    </svg> {{str "delete"}}</li>
+                    <li class="action-classic">
+                    <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                      <use xlink:href="chrome://conversations/skin/material-icons.svg#open_in_new"></use>
+                    </svg> {{str "viewClassic"}}</li>
+                    <li class="action-source">
+                    <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                      <use xlink:href="chrome://conversations/skin/material-icons.svg#code"></use>
+                    </svg> {{str "viewSource"}}</li>
+                    <li class="action-print" style="display: none;">
+                    <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                      <use xlink:href="chrome://conversations/skin/material-icons.svg#print"></use>
+                    </svg> {{str "print"}}</li>
+                  </ul>
+                </div>
+              </span>
             </div>
-            <div class="editRecipientList editBccList hbox" style="display: none">
-              <div class="label">{{str "fieldBcc"}}</div>
-              <div class="boxFlex"><input type="text" id="bcc" /></div>
-            </div>
-            <div class="editRecipientList editSubject hbox" style="display: none">
-              <div class="label">{{str "fieldSubject"}}</div>
-              <div class="boxFlex"><input type="text" id="subject" /></div>
-            </div>
-            <ul class="recipientList toList">
-              {{str "fieldTo"}}
-              <li>{{str "pleaseWait"}}</li>
-              <li class="add-more">&#xa0;- <a href="javascript:" onclick="editFields('to');">{{str "edit"}}</a></li>
-            </ul>
-            <ul class="recipientList ccList" style="display: none;">
-              {{str "fieldCc"}}
-              <li>{{str "pleaseWait"}}</li>
-              <li class="add-more">&#xa0;- <a href="javascript:" onclick="editFields('cc');">{{str "edit"}}</a></li>
-            </ul>
-            <ul class="recipientList bccList" style="display: none;">
-              {{str "fieldBcc"}}
-              <li>{{str "pleaseWait"}}</li>
-              <li class="add-more">&#xa0;- <a href="javascript:" onclick="editFields('bcc');">{{str "edit"}}</a></li>
-            </ul>
           </div>
-          <ul class="enigmail" style="display: none;">
-            <li class="replyEncrypt">
-              <input type="checkbox" name="enigmail-reply-encrypt" id="enigmail-reply-encrypt"
-              /><label for="enigmail-reply-encrypt">{{str "encrypt"}}</label>
-            </li>
-            <li class="replySign">
-              <input type="checkbox" name="enigmail-reply-sign" id="enigmail-reply-sign"
-              /><label for="enigmail-reply-sign">{{str "sign"}}</label>
-            </li>
-            <li class="replyPgpMime">
-              <input type="checkbox" name="enigmail-reply-pgpmime" id="enigmail-reply-pgpmime"
-              /><label for="enigmail-reply-pgpmime">PGP/MIME</label>
-            </li>
-          </ul>
-          <div class="quickReplyAttachments">
+
+          <div class="detailsPlaceholder show-with-details">
           </div>
-          <div class="quickReplyHeader" style="display: none; overflow: auto">
-            <span class="statusMessage" style="float: left;"></span>
-            <span class="statusPercentage" style="float: right;"></span>
-            <span class="statusThrobber" style="float: right;">
-              <img src="chrome://conversations/content/i/loader.gif"
-                style="vertical-align: middle;" />
+
+          <div class="detailsLine">
+            {{tmpl "attachmentDetails" this}}
+          </div>
+
+          {{#if generateLightningTempl}}
+          <div class="lightningImipBar notificationBar" style="display: none">
+            <img class="lightningImipImage" src="chrome://calendar/skin/cal-icon32.png"/>
+            <span class="lightningImipText"></span>
+            <!-- The text for all these buttons is filled dynamically -->
+
+            <!-- show event/invitation details -->
+            <button id="imipDetailsButton"
+                    class="lightningImipButton msgHeaderView-button imipDetailsButton"
+                    onclick="ltnImipBar.executeAction('X-SHOWDETAILS')"
+                    style="display: none">
+            </button>
+
+            <!-- add published events -->
+            <button id="imipAddButton"
+                    class="lightningImipButton msgHeaderView-button imipAddButton"
+                    onclick="ltnImipBar.executeAction()"
+                    style="display: none">
+            </button>
+
+            <!-- update published events and invitations -->
+            <button id="imipUpdateButton"
+                    class="lightningImipButton msgHeaderView-button imipUpdateButton"
+                    onclick="ltnImipBar.executeAction()"
+                    style="display: none">
+            </button>
+
+            <!-- delete cancelled events from calendar -->
+            <button id="imipDeleteButton"
+                    class="lightningImipButton msgHeaderView-button imipDeleteButton"
+                    onclick="ltnImipBar.executeAction()"
+                    style="display: none">
+            </button>
+
+            <!-- re-confirm partstat -->
+            <button id="imipReconfirmButton"
+                    class="lightningImipButton msgHeaderView-button imipReconfirmButton"
+                    onclick="ltnImipBar.executeAction()"
+                    style="display: none">
+            </button>
+
+            <!-- accept -->
+            <button id="imipAcceptButton"
+                    onclick="if (event.target.id == this.id) ltnImipBar.executeAction('ACCEPTED');"
+                    type="menu-button"
+                    class="imip-button lightningImipButton msgHeaderView-button imipAcceptButton"
+                    style="display: none">
+              <menupopup id="imipAcceptDropdown">
+                <menuitem id="imipAcceptButton_Accept" onclick="ltnImipBar.executeAction('ACCEPTED');"/>
+                <menuitem id="imipAcceptButton_Tentative" onclick="ltnImipBar.executeAction('TENTATIVE');"/>
+                <!-- add here more menuitem as needed -->
+              </menupopup>
+            </button>
+
+            <!-- accept recurrences -->
+            <button id="imipAcceptRecurrencesButton"
+                    onclick="if (event.target.id == this.id) ltnImipBar.executeAction('ACCEPTED');"
+                    type="menu-button"
+                    class="imip-button lightningImipButton msgHeaderView-button imipAcceptRecurrencesButton"
+                    style="display: none">
+              <menupopup id="imipAcceptRecurrencesDropdown">
+                <menuitem id="imipAcceptRecurrencesButton_Accept" onclick="ltnImipBar.executeAction('ACCEPTED');"/>
+                <menuitem id="imipAcceptRecurrencesButton_Tentative" onclick="ltnImipBar.executeAction('TENTATIVE');"/>
+                <!-- add here more menuitem as needed -->
+              </menupopup>
+            </button>
+
+            <!-- tentative; should only be used, if no imipMoreButton is used and
+               - imipDeclineButton/imipAcceptButton have no visible menuitems //-->
+            <button id="imipTentativeButton"
+                    class="lightningImipButton msgHeaderView-button imipTentativeButton"
+                    onclick="if (event.target.id == this.id) ltnImipBar.executeAction('TENTATIVE');"
+                    type="menu-button"
+                    style="display: none">
+              <menupopup id="imipTentativeDropdown">
+                <menuitem id="imipTentativeButton_Tentative" onclick="ltnImipBar.executeAction('TENTATIVE');"/>
+                <!-- add here more menuitem as needed -->
+              </menupopup>
+            </button>
+
+            <!-- tentative recurrences; should only be used, if no imipMoreButton is used and
+               - imipDeclineRecurrencesButton/imipAcceptRecurrencesButton have no visible menuitems //-->
+            <button id="imipTentativeRecurrencesButton"
+                    class="lightningImipButton msgHeaderView-button imipTentativeRecurrencesButton"
+                    onclick="if (event.target.id == this.id) ltnImipBar.executeAction('TENTATIVE');"
+                    type="menu-button"
+                    style="display: none">
+              <menupopup id="imipTentativeRecurrencesDropdown">
+                <menuitem id="imipTentativeRecurrencesButton_Tentative" onclick="ltnImipBar.executeAction('TENTATIVE');"/>
+                <!-- add here more menuitem as needed -->
+              </menupopup>
+            </button>
+
+            <!-- decline -->
+            <button id="imipDeclineButton"
+                    onclick="if (event.target.id == this.id) ltnImipBar.executeAction('DECLINED');"
+                    type="menu-button"
+                    class="lightningImipButton msgHeaderView-button imipDeclineButton"
+                    style="display: none">
+              <menupopup id="imipDeclineDropdown">
+                <menuitem id="imipDeclineButton_Decline" onclick="ltnImipBar.executeAction('DECLINED');"/>
+                <!-- add here more menuitem as needed -->
+              </menupopup>
+            </button>
+
+            <!-- decline recurrences -->
+            <button id="imipDeclineRecurrencesButton"
+                    onclick="if (event.target.id == this.id) ltnImipBar.executeAction('DECLINED');"
+                    type="menu-button"
+                    class="lightningImipButton msgHeaderView-button imipDeclineRecurrencesButton"
+                    style="display: none">
+              <menupopup id="imipDeclineRecurrencesDropdown">
+                <menuitem id="imipDeclineRecurrencesButton_DeclineAll" onclick="ltnImipBar.executeAction('DECLINED');"/>
+                <!-- add here more menuitem as needed -->
+              </menupopup>
+            </button>
+
+            <!-- more options -->
+            <button id="imipMoreButton"
+                    type="menu"
+                    class="lightningImipButton msgHeaderView-button imipMoreButton"
+                    style="display: none">
+              <menupopup id="imipMoreDropdown">
+                <!-- add here a menuitem as needed -->
+              </menupopup>
+            </button>
+          </div>
+          {{/if}}
+
+          <div class="phishingBar notificationBar" style="display: none">
+            <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+              <use xlink:href="chrome://conversations/skin/material-icons.svg#warning"></use>
+            </svg>
+            {{str "scam"}}
+            <span class="ignore-warning">
+              <a href="javascript:">
+                {{str "ignoreWarning"}}
+              </a>
             </span>
           </div>
-        </div>
 
-        <ul class="inputs">
-          <li class="reply expand" ondragenter="quickReplyDragEnter(event);">
-            <div class="textWrap">
-              <div class="quickReplyIcon"><span>{{str "reply"}}</span> <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="chrome://conversations/skin/material-icons.svg#reply"></use></svg></div>
-              <iframe mozframetype="content" class="textarea sans"></iframe>
-            </div>
-          </li>
+          <div class="remoteContent notificationBar" style="display: none">
+            {{str "remoteContentBlocked"}}
+            <span class="show-remote-content">
+              <a href="javascript:">
+                {{str "showRemote"}}
+              </a> -
+            </span>
+            <span class="always-display">
+              <a href="javascript:">
+                {{str "alwaysShowRemote" realFrom}}
+              </a>
+            </span>
+          </div>
 
-          <li class="replyAll expand" ondragenter="quickReplyDragEnter(event);">
-            <div class="textWrap">
-              <div class="quickReplyIcon"><span>{{str "replyAll"}}</span> <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="chrome://conversations/skin/material-icons.svg#reply_all"></use></svg></div>
-              <iframe mozframetype="content" class="textarea sans"></iframe>
-            </div>
-          </li>
-        </ul>
-
-        <div class="replyFooter" style="overflow: auto" tabindex="-1">
-          <button id="send" style="float:right;margin-left:3px;" onclick="gComposeSession.send();">
-            {{str "send"}}
-          </button>
-          <button id="sendArchive" style="float:right;margin-left:3px;"
-              onclick="gComposeSession.send({ archive: true });">
-            {{str "sendArchive"}}
-          </button>
-          <button id="save" style="float:right" onclick="onSave();">{{str "save"}}</button>
-          <a class="discard" href="javascript:" id="discard" onclick="confirmDiscard()">
-            {{str "discard"}}
-          </a>
-        </div>
-      </div>
-    </div>
-    ]]>
-  </script>
-  <script id="quickReplyAttachmentTemplate" type="text/x-handlebars-template"><![CDATA[
-    <ul class="quickReplyAttachment">
-      {{str "attachment"}}:
-      <li>{{name}}</li> ({{size}}) -
-      <a href="javascript:" class="openAttachmentLink">{{str "open"}}</a> -
-      <a href="javascript:" class="removeAttachmentLink">{{str "removeAttachment"}}</a>
-    </ul>
-    ]]>
-  </script>
-  <div id="wrapper">
-    <div id="conversationHeaderWrapper">
-      <div id="conversationHeader" class="hbox">
-        <div class="subject boxFlex">&stub.loading;</div>
-        <div class="actions">
-          <button class="button-flat" title="&stub.trash.tooltip;" onclick="deleteToolbar(event);">
-            <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="chrome://conversations/skin/material-icons.svg#delete"></use></svg>
-          </button>
-          <button class="button-flat" title="&stub.archive.tooltip;" onclick="archiveToolbar(event);">
-            <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="chrome://conversations/skin/material-icons.svg#archive"></use></svg>
-          </button>
-          <button class="button-flat junk-button" title="&stub.junk.tooltip;" onclick="junkConversation(event);">
-            <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="chrome://conversations/skin/material-icons.svg#whatshot"></use></svg>
-          </button>
-          <button class="button-flat" title="&stub.expand.tooltip;" onclick="expandCollapse(event);">
-            <svg class="icon expand" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-              <use class="expand-more" xlink:href="chrome://conversations/skin/material-icons.svg#expand_more"></use>
-              <use class="expand-less" xlink:href="chrome://conversations/skin/material-icons.svg#expand_less"></use>
+          <div class="junkBar notificationBar" {{#unless canUnJunk}}style="display: none"{{/unless}}>
+            <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+              <use xlink:href="chrome://conversations/skin/material-icons.svg#whatshot"></use>
             </svg>
-          </button>
-          <button class="button-flat" title="&stub.read.tooltip;" onclick="toggleRead(event);">
-            <svg class="icon read" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="chrome://conversations/skin/material-icons.svg#visibility"></use></svg>
-          </button>
-          <button class="button-flat" title="&stub.detach.tooltip2;" onclick="detachTab(event);">
-            <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="chrome://conversations/skin/material-icons.svg#open_in_new"></use></svg>
-          </button>
-          <!--<button><span class="mode"></span></button>-->
+            {{str "junk"}}
+            <span class="notJunk">
+              <a href="javascript:">
+                {{str "notJunk"}}
+              </a>
+            </span>
+          </div>
+
+          <div class="outboxBar notificationBar" {{#unless isOutbox}}style="display: none"{{/unless}}>
+            <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+              <use xlink:href="chrome://conversations/skin/material-icons.svg#inbox"></use>
+            </svg>
+            {{str "isOutbox"}}
+            <span class="sendUnsent">
+              <a href="javascript:">
+                {{str "sendUnsent"}}
+              </a>
+            </span>
+          </div>
+
+          <div class="enigmailBar notificationBar" style="display: none">
+            <span class="enigmailMessage"></span>
+            <span class="enigmailDetails">
+              <button>{{str "Details"}}</button>
+            </span>
+          </div>
+
+          <div class="messageBody">
+            <ul class="tags special-tags">
+              <li class="keep-tag tag-signed" title="{{str 'messageSignedLong'}}">
+                <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                  <use xlink:href="chrome://conversations/skin/material-icons.svg#edit"></use>
+                </svg>
+                {{str "messageSigned"}}
+              </li>
+              <li class="keep-tag tag-decrypted"
+                title="{{str 'messageDecryptedLong'}}">
+                <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                  <use xlink:href="chrome://conversations/skin/material-icons.svg#vpn_key"></use>
+                </svg>
+                {{str "messageDecrypted"}}
+              </li>
+              <li class="keep-tag tag-dkim-signed">
+                <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                  <use xlink:href="chrome://conversations/skin/material-icons.svg#edit"></use>
+                </svg>
+                {{str "messageDKIMSigned"}}
+              </li>
+              <li class="keep-tag in-folder" title="{{str 'jumpToFolder'}}">
+                {{str "inFolder" folderName}}
+              </li>
+            </ul>
+            <ul class="tags regular-tags"></ul>
+            <div class="iframe-container"></div>
+            <div class="body-container"></div>
+            <div class="attachments-container">
+              {{tmpl "attachments" this}}
+            </div>
+            <div class="embedsContainer">
+            </div>
+          </div>
+
+          <div class="messageFooter">
+            <div class="footerActions">
+              <button class="edit-draft" title="{{str 'editDraft2'}}">
+                <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                  <use xlink:href="chrome://conversations/skin/material-icons.svg#edit"></use>
+                </svg>
+              </button>
+              <button class="buttonReply" title="{{str 'reply'}}">
+                <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                  <use xlink:href="chrome://conversations/skin/material-icons.svg#reply"></use>
+                </svg>
+              </button>
+              <button class="buttonReplyAll" title="{{str 'replyAll'}}">
+                <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                  <use xlink:href="chrome://conversations/skin/material-icons.svg#reply_all"></use>
+                </svg>
+              </button>
+              <button class="buttonReplyList" title="{{str 'replyList'}}">
+                <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                  <use xlink:href="chrome://conversations/skin/material-icons.svg#list"></use>
+                </svg>
+              </button>
+              <button class="buttonForward" title="{{str 'forward'}}">
+                <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                  <use xlink:href="chrome://conversations/skin/material-icons.svg#forward"></use>
+                </svg>
+              </button>
+            </div>
+          </div>
+
+          {{#if quickReply}}
+            {{tmpl "quickReply" this}}
+          {{/if}}
+
+        </li>
+        ]]>
+    </script>
+
+    <!-- Generic contact template with tooltip -->
+    <script id="contactTemplate" type="text/x-handlebars-template">
+      <![CDATA[
+        {{tmpl "contactLabel" this}}
+        {{tmpl "contactTooltip" this}}
+      ]]>
+    </script>
+
+    <!-- Contact template specific to recipients, without tooltip -->
+    <script id="contactLabelTemplate" type="text/x-handlebars-template">
+      <![CDATA[
+        <span>{{separator}}</span>
+        <span class="tooltipWrapper contact">
+          <span class="contactName" style="{{colorStyle}}">
+
+            {{#if star}}
+            &#x2605;
+            {{/if}}
+
+            {{trim name}}
+
+            {{#if extra}}
+            <label xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul" crop="center" class="contactExtra" value="({{extra}})"/>
+            {{/if}}
+
+            {{#if displayEmail}}
+            <span class="smallEmail"> &lt;{{trim displayEmail}}&gt;</span>
+            {{/if}}
+
+            {{#if writeBr}}
+            <br />
+            {{/if}}
+
+          </span>
+        </span>
+      ]]>
+    </script>
+
+    <!-- Tooltip template specific to recipients -->
+    <script id="contactTooltipTemplate" type="text/x-handlebars-template">
+      <![CDATA[
+        <span class="contactTooltipWrapper contact">{{tmpl "innerTooltip" this}}</span>
+      ]]>
+    </script>
+
+    <!-- Inner tooltip template, to be used by other templates. Currently only used by the template above. -->
+    <script id="innerTooltipTemplate" type="text/x-handlebars-template">
+      <![CDATA[
+        <div class="tooltip">
+          <div class="arrow"></div>
+          <div class="arrow inside"></div>
+          <div class="authorInfoContainer">
+            <div class="authorInfo">
+              <span class="name" title="{{tooltipName}}">{{tooltipName}}</span>
+              <span class="authorEmail">
+                <span class="authorEmailAddress" title="{{email}}">{{email}}</span>
+                <button class="copyEmail" title="{{str 'copyEmail'}}">
+                  <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                    <use xlink:href="chrome://conversations/skin/material-icons.svg#content_copy"></use>
+                  </svg>
+                </button>
+              </span>
+            </div>
+            <div class="authorPicture">
+              <img src="{{avatar}}" />
+            </div>
+          </div>
+          <div class="tipFooter hiddenFooter" style="display:none;">
+
+            {{#if showMonospace}}
+            <div style="margin-bottom:5px;">
+              <input type="checkbox" style="vertical-align: text-top" class="checkbox-monospace" />
+              <label style="color:#666; font-weight: normal">{{str "messagesMonospace"}}</label>
+            </div>
+            {{/if}}
+
+            <button class="createFilter">{{str "createFilter"}}</button>
+            <button class="addContact" title="{{str 'addToAb'}}">
+              <img src="chrome://conversations/content/i/user_add.png" />
+            </button>
+            <button class="editContact" title="{{str 'editCardAb'}}">
+              <img src="chrome://conversations/content/i/user_edit.png" />
+            </button>
+          </div>
+          <div class="tipFooter">
+            <button class="sendEmail">{{str "sendEmail"}}</button>
+            <button class="showInvolving">{{str "recentConversations"}}</button>
+            <button class="moreExpander">+</button>
+          </div>
+        </div>
+      ]]>
+    </script>
+
+    <script id="attachmentIconTemplate" type="text/x-handlebars-template">
+      <![CDATA[
+
+        {{#if attachments.length}}
+          <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <use xlink:href="chrome://conversations/skin/material-icons.svg#attachment"></use>
+          </svg>
+        {{/if}}
+
+      ]]>
+    </script>
+
+    <script id="attachmentDetailsTemplate" type="text/x-handlebars-template">
+      <![CDATA[
+
+        {{#if attachments.length}}
+          <u>{{attachmentsPlural}}:</u>
+
+          {{#each attachments}}
+            <a href="javascript:" onclick="scrollNodeIntoView(document.getElementById('{{anchor}}'));">
+              {{name}} ({{formattedSize}})
+            </a>
+            {{sep}}
+          {{/each}}
+
+        {{/if}}
+
+      ]]>
+    </script>
+
+    <script id="attachmentsTemplate" type="text/x-handlebars-template">
+      <![CDATA[
+        {{#if attachments.length}}
+          <ul class="attachments">
+            <div class="attachHeader">
+              {{attachmentsPlural}}
+              |
+              <a href="javascript:" class="link download-all">
+                {{str "downloadAll2"}}
+              </a>
+
+              {{#if gallery}}
+              |
+              <a href="javascript:" onclick="galleryView('{{uri}}')" class="link view-all">
+                {{str "galleryView"}}
+              </a>
+              {{/if}}
+
+            </div>
+
+            {{#each attachments}}
+            <li class="clearfix hbox attachment" draggable="true" id="{{anchor}}">
+              <div class="attachmentThumb">
+                <img onload="$(this).closest('.attachment').find('.align').vAlign()"
+                class="{{imgClass}}" src="{{thumb}}" />
+              </div>
+              <div class="attachmentInfo align">
+                <span class="filename">{{name}}</span>
+                <div class="attachActions">
+                  {{formattedSize}}
+
+                  {{#if canPreview}}
+                  |
+                  <a href="javascript:" class="link preview-attachment">
+                    {{str "preview"}}
+                  </a>
+                  {{/if}}
+
+                  |
+                  <a href="javascript:" class="link open-attachment">
+                    {{str "open"}}
+                  </a>
+                  |
+                  <a href="javascript:" class="link download-attachment">
+                    {{str "download2"}}
+                  </a>
+                </div>
+              </div>
+            </li>
+            {{/each}}
+
+          </ul>
+        {{/if}}
+
+      ]]>
+    </script>
+
+    <script id="popularContactTemplate" type="text/x-handlebars-template">
+      <![CDATA[
+        <div class="popularContact">
+          <img class="popularPhoto" src="{{photo}}" style="float: left" />
+          <span class="popularRemove">×</span>
+          <span class="popularName">{{name}}</span><br />
+          <span class="popularEmail">{{email}}</span>
+        </div>
+      ]]>
+    </script>
+
+    <script id="quickReplyTemplate" type="text/x-handlebars-template">
+      <![CDATA[
+        <div class="quickReply" ondragover="quickReplyCheckDrag(event);" ondrop="quickReplyDrop(event);">
+
+          <div class="quickReplyContacts">
+            <div class="quickReplyContactsHeader">
+              {{str "mostFrequentContacts"}}
+            </div>
+            <div class="quickReplyContactsBox">
+            </div>
+            <div class="quickReplyContactsMore">
+              <a class="quickReplyContactsMoreLink">
+                {{str "showMore"}}
+              </a>
+            </div>
+          </div>
+
+          <div class="quickReplyBox">
+            <div class="replyHeader">
+              <div class="quickReplyRecipients">
+                <ul class="fromField">
+                  {{str "fieldFrom"}}
+                  <li class="senderSwitcher">
+                    <a class="switchLeft" onclick="gComposeSession.cycleSender(-1)">◂</a>
+                    <a class="switchRight" onclick="gComposeSession.cycleSender(1)">▸</a>
+                  </li>
+                  <li class="senderName"></li>,
+                  <li class="replyMethod">
+                    <input type="radio" name="reply-method" value="reply"
+                      onchange="changeComposeFields('reply')" id="reply-radio"/>
+                    <label for="reply-radio">{{str "reply"}}</label>
+                  </li>
+                  <li class="replyMethod replyMethod-replyAll">
+                    <input type="radio" name="reply-method" value="replyAll"
+                      onchange="changeComposeFields('replyAll')" id="replyAll-radio" />
+                    <label for="replyAll-radio">{{str "replyAll"}}</label>
+                  </li>
+                  <li class="replyMethod replyMethod-replyList">
+                    <input type="radio" name="reply-method" value="replyList"
+                      onchange="changeComposeFields('replyList')" id="replyList-radio" />
+                    <label for="replyList-radio">{{str "replyList"}}</label>
+                  </li>
+                  <li class="replyMethod">
+                    <input type="radio" name="reply-method" value="forward"
+                      onchange="changeComposeFields('forward')" id="forward-radio" />
+                    <label for="forward-radio">{{str "forward"}}</label>
+                  </li>
+                  <li class="firstBar">|</li>
+                  <li class="showCc"><a onclick="showCc(); editFields('cc');" href="javascript:">{{str "addCc"}}</a> |</li>
+                  <li class="showBcc"><a onclick="showBcc(); editFields('bcc');" href="javascript:">{{str "addBcc"}}</a> |</li>
+                  <li class="addAttachment"><a onclick="addAttachment();" href="javascript:">{{str "addAttachment"}}</a></li>
+                </ul>
+                <div class="editRecipientList editToList hbox">
+                  <div class="label">{{str "fieldTo"}}</div>
+                  <div class="boxFlex"><input type="text" id="to"/></div>
+                </div>
+                <div class="editRecipientList editCcList hbox" style="display: none">
+                  <div class="label">{{str "fieldCc"}}</div>
+                  <div class="boxFlex"><input type="text" id="cc"/></div>
+                </div>
+                <div class="editRecipientList editBccList hbox" style="display: none">
+                  <div class="label">{{str "fieldBcc"}}</div>
+                  <div class="boxFlex"><input type="text" id="bcc"/></div>
+                </div>
+                <div class="editRecipientList editSubject hbox" style="display: none">
+                  <div class="label">{{str "fieldSubject"}}</div>
+                  <div class="boxFlex"><input type="text" id="subject" /> </div>
+                </div>
+                <ul class="recipientList toList">
+                  {{str "fieldTo"}}
+                  <li>{{str "pleaseWait"}}</li>
+                  <li class="add-more">&#xa0;-
+                    <a href="javascript:" onclick="editFields('to');">
+                      {{str "edit"}}
+                    </a>
+                  </li>
+                </ul>
+                <ul class="recipientList ccList" style="display: none;">
+                  {{str "fieldCc"}}
+                  <li>{{str "pleaseWait"}}</li>
+                  <li class="add-more">&#xa0;-
+                    <a href="javascript:" onclick="editFields('cc');">
+                      {{str "edit"}}
+                    </a>
+                  </li>
+                </ul>
+                <ul class="recipientList bccList" style="display: none;">
+                  {{str "fieldBcc"}}
+                  <li>{{str "pleaseWait"}}</li>
+                  <li class="add-more">&#xa0;-
+                    <a href="javascript:" onclick="editFields('bcc');">
+                      {{str "edit"}}
+                    </a>
+                  </li>
+                </ul>
+              </div>
+              <ul class="enigmail" style="display: none;">
+                <li class="replyEncrypt">
+                  <input type="checkbox" name="enigmail-reply-encrypt" id="enigmail-reply-encrypt"
+                  />
+                  <label for="enigmail-reply-encrypt">{{str "encrypt"}}</label>
+                </li>
+                <li class="replySign">
+                  <input type="checkbox" name="enigmail-reply-sign" id="enigmail-reply-sign"
+                  />
+                  <label for="enigmail-reply-sign">{{str "sign"}}</label>
+                </li>
+                <li class="replyPgpMime">
+                  <input type="checkbox" name="enigmail-reply-pgpmime" id="enigmail-reply-pgpmime"
+                  />
+                  <label for="enigmail-reply-pgpmime">PGP/MIME</label>
+                </li>
+              </ul>
+              <div class="quickReplyAttachments">
+              </div>
+              <div class="quickReplyHeader" style="display: none; overflow: auto">
+                <span class="statusMessage" style="float: left;"></span>
+                <span class="statusPercentage" style="float: right;"></span>
+                <span class="statusThrobber" style="float: right;">
+                  <img src="chrome://conversations/content/i/loader.gif"
+                    style="vertical-align: middle;" />
+                </span>
+              </div>
+            </div>
+
+            <ul class="inputs">
+              <li class="reply expand" ondragenter="quickReplyDragEnter(event);">
+                <div class="textWrap">
+                  <div class="quickReplyIcon">
+                    <span>{{str "reply"}}</span>
+                    <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                      <use xlink:href="chrome://conversations/skin/material-icons.svg#reply"></use>
+                    </svg>
+                  </div>
+                  <iframe mozframetype="content" class="textarea sans"></iframe>
+                </div>
+              </li>
+              <li class="replyAll expand" ondragenter="quickReplyDragEnter(event);">
+                <div class="textWrap">
+                  <div class="quickReplyIcon">
+                    <span>{{str "replyAll"}}</span>
+                    <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                      <use xlink:href="chrome://conversations/skin/material-icons.svg#reply_all"></use>
+                    </svg>
+                  </div>
+                  <iframe mozframetype="content" class="textarea sans"></iframe>
+                </div>
+              </li>
+            </ul>
+
+            <div class="replyFooter" style="overflow: auto" tabindex="-1">
+              <button id="send" style="float:right;margin-left:3px;" onclick="gComposeSession.send();">
+                {{str "send"}}
+              </button>
+              <button id="sendArchive" style="float:right;margin-left:3px;" onclick="gComposeSession.send({ archive: true });">
+                {{str "sendArchive"}}
+              </button>
+              <button id="save" style="float:right" onclick="onSave();">{{str "save"}}</button>
+              <a class="discard" href="javascript:" id="discard" onclick="confirmDiscard()">
+                {{str "discard"}}
+              </a>
+            </div>
+
+          </div>
+
+        </div>
+        ]]>
+    </script>
+
+    <script id="quickReplyAttachmentTemplate" type="text/x-handlebars-template">
+      <![CDATA[
+        <ul class="quickReplyAttachment">
+          {{str "attachment"}}: <li>{{name}}</li> ({{size}}) -
+          <a href="javascript:" class="openAttachmentLink">
+            {{str "open"}}
+          </a>
+          -
+          <a href="javascript:" class="removeAttachmentLink">
+            {{str "removeAttachment"}}
+          </a>
+        </ul>
+      ]]>
+    </script>
+    <div id="wrapper">
+      <div id="conversationHeaderWrapper">
+        <div id="conversationHeader" class="hbox">
+          <div class="subject boxFlex">&stub.loading;</div>
+          <div class="actions">
+            <button class="button-flat" title="&stub.trash.tooltip;" onclick="deleteToolbar(event);">
+              <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <use xlink:href="chrome://conversations/skin/material-icons.svg#delete"></use>
+              </svg>
+            </button>
+            <button class="button-flat" title="&stub.archive.tooltip;" onclick="archiveToolbar(event);">
+              <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <use xlink:href="chrome://conversations/skin/material-icons.svg#archive"></use>
+              </svg>
+            </button>
+            <button class="button-flat junk-button" title="&stub.junk.tooltip;" onclick="junkConversation(event);">
+              <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <use xlink:href="chrome://conversations/skin/material-icons.svg#whatshot"></use>
+              </svg>
+            </button>
+            <button class="button-flat" title="&stub.expand.tooltip;" onclick="expandCollapse(event);">
+              <svg class="icon expand" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <use class="expand-more" xlink:href="chrome://conversations/skin/material-icons.svg#expand_more"></use>
+                <use class="expand-less" xlink:href="chrome://conversations/skin/material-icons.svg#expand_less"></use>
+              </svg>
+            </button>
+            <button class="button-flat" title="&stub.read.tooltip;" onclick="toggleRead(event);">
+              <svg class="icon read" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <use xlink:href="chrome://conversations/skin/material-icons.svg#visibility"></use>
+              </svg>
+            </button>
+            <button class="button-flat" title="&stub.detach.tooltip2;" onclick="detachTab(event);">
+              <svg class="icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                <use xlink:href="chrome://conversations/skin/material-icons.svg#open_in_new"></use>
+              </svg>
+            </button>
+            <!--<button><span class="mode"></span></button>-->
+          </div>
         </div>
       </div>
+      <ul id="messageList">
+      </ul>
+      <div class="bottom-links">
+        <a class="link" href="javascript:" onclick="forwardConversation(event);">
+          &stub.forward.tooltip;</a> –
+        <a class="link" href="javascript:" onclick="printConversation(event);">
+          &stub.print.tooltip;</a>
+      </div>
     </div>
-    <ul id="messageList">
-    </ul>
-    <div class="bottom-links">
-      <a class="link" href="javascript:" onclick="forwardConversation(event);">
-        &stub.forward.tooltip;</a> –
-      <a class="link" href="javascript:" onclick="printConversation(event);">
-        &stub.print.tooltip;</a>
-    </div>
-  </div>
-</body>
+  </body>
 </html>


### PR DESCRIPTION
Elaborate version of clean-ups originally done for #1145.

- fix weird linebreaks in tags
- indent inline JS properly
- insert indentation/linebreaks for proper hierarchical structuring
- insert empty lines for readability

I tested the changes, nothing seems to be broken through the reformatting.  
The formatting is quite subjective, except for the pure JS i did not use any standard code-clean tools (since i dont know any for XHTML+ inline JS)