### PR TITLE
New tag/label design

### DIFF
--- a/skin/conversation.css
+++ b/skin/conversation.css
@@ -474,18 +474,23 @@ span.downwardArrow {
 .tags li {
   display: inline-block;
   font-size: 1.0rem;
-  line-height: 1.6;
-  padding: 0 .8em;
+  line-height: 1.8;
+  padding: 0 .9em;
   margin-right: .4rem;
-  border-radius: .8em;
+  border-radius: .9em;
   color: #fff;
 }
 
 .tag-x {
-  border-left: 1px solid ThreeDShadow;
-  margin-left: 1ex;
+  display: inline-block;
   cursor: pointer;
-  z-index: 3;
+  text-align: center;
+  font-weight: bold;
+  width: 1.8em;
+  margin-right: -0.9em;
+  border-radius: .9em;
+  margin-left: .5em;
+  background-color: rgba(255,255,255,0.4);
 }
 
 .messageHeader .tag-x {


### PR DESCRIPTION
Labelicious! Blatantly stolen from @xi's original mockup (5459a32).  

I'm not quite sure but the alignment seems to be off for collapsed messages.
Screen includes changes from #1157.

![new-labels](https://cloud.githubusercontent.com/assets/15898292/23592340/94b15f2a-01ff-11e7-9427-81b2514afe57.png)
