### PR TITLE
rename attachment icon to .mime-icon

### DIFF
--- a/modules/message.js
+++ b/modules/message.js
@@ -614,7 +614,7 @@ Message.prototype = {
       let url = att.url.replace(self.RE_MSGKEY, "number="+key);
       let [thumb, imgClass] = isImage
         ? [url, "resize-me"]
-        : ["chrome://conversations/skin/icons/"+iconForMimeType(att.contentType), "icon"]
+        : ["chrome://conversations/skin/icons/"+iconForMimeType(att.contentType), "mime-icon"]
       ;
 
       // This is bug 630011, remove when fixed

--- a/skin/conversation.css
+++ b/skin/conversation.css
@@ -666,7 +666,7 @@ a img {
 }
 
 /* For moz-icons */
-.attachmentThumb img.icon {
+.attachmentThumb img.mime-icon {
   height: auto;
   width: 48px;
 }


### PR DESCRIPTION
Fixes #1178.

The issue was that there was a naming conflict with SVG icons (which also use the `.icon` class). 6cbae7c1 made them non-clickable.