### PR TITLE
Update the querySelector for looking at bugzilla emails, so that selecting them works again.

### DIFF
--- a/content/stub.compose-ui-bz.js
+++ b/content/stub.compose-ui-bz.js
@@ -84,17 +84,17 @@ function bzSetup() {
       let cookie = getBugzillaCookie(url);
       let bzUrl = gBugzillaAPIs[url];
       if (cookie) {
-        document.querySelector(".quickReply li.reply .icon span")
+        document.querySelector(".quickReply li.reply .quickReplyIcon span")
           .textContent = strings.get("bzPlaceholder");
         return [url, bzUrl, cookie];
       } else {
-        document.querySelector(".quickReply li.reply .icon span")
+        document.querySelector(".quickReply li.reply .quickReplyIcon span")
           .textContent = strings.get("bzNoCookieMsg");
         addBzLink(url);
         return null;
       }
     } else {
-      document.querySelector(".quickReply li.reply .icon span")
+      document.querySelector(".quickReply li.reply .quickReplyIcon span")
         .textContent = strings.get("bzNoApiUrlMsg");
       return null;
     }


### PR DESCRIPTION
This seems to be an issue on latest master - selecting a Bugzilla message results in an email view, that is mostly complete, but significantly the email doesn't get marked as read.

Looks like something changed the class names and broke the selector rules, and in turn this broke updating the display.

This seems to fix it for me.