### PR TITLE
Center contact photo

### DIFF
--- a/skin/conversation.css
+++ b/skin/conversation.css
@@ -366,6 +366,7 @@ a img {
   text-align: center;
   color: #fff;
   background-size: cover;
+  background-position: center;
 }
 
 .smallEmail {


### PR DESCRIPTION
When the contact photo does not have a quadratic size, the leftmost excerpt is shown. As contact photos usually contains centered pictures of a person's face, it is not helpful to start showing the photo from the left. Instead, it should be centered and the center portion should be shown.