### PR TITLE
Fixes #1195: Correct the modifier matching actions for keypresses so that it works correctly

### DIFF
--- a/modules/message.js
+++ b/modules/message.js
@@ -345,8 +345,11 @@ KeyListener.prototype = {
         let actions = binding[key];
         for (let action of actions) {
           let match = true;
-          for (let mod of entries(action.mods))
-            match = match && (action.mods[mod] == event[mod]);
+          for (let mod in action.mods) {
+            if (action.mods.hasOwnProperty(mod)) {
+              match = match && (action.mods[mod] == event[mod]);
+            }
+          }
           if (match) {
             let func = this.functions[action.func];
             if (typeof func === "function")


### PR DESCRIPTION
Hence cmd-A (but not just 'A') is passed up the event chain in the preview panel and works correctly as select-all.