### PR TITLE
Fix(general): Enable the no-undef rule for most of the add-on.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,6 @@
 "use strict";
 
+/* eslint-env node */
 /* eslint sort-keys: "error" */
 
 module.exports = {
@@ -37,7 +38,7 @@ module.exports = {
     "no-native-reassign": "off",
     "no-nested-ternary": "off",
     "no-trailing-spaces": "off",
-    "no-undef": "off",
+    "no-undef": "error",
     "no-unused-vars": "off",
     "no-useless-call": "off",
     "object-shorthand": "off",

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -43,7 +43,7 @@ const Cr = Components.results;
 
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 Cu.import("resource://gre/modules/Services.jsm");
-Cu.import("resource:///modules/iteratorUtils.jsm");
+const {fixIterator} = Cu.import("resource:///modules/iteratorUtils.jsm", {});
 
 let global = this;
 let Log;
@@ -145,9 +145,12 @@ function monkeyPatchAllWindows() {
  * Cu.import() just loads every imported file once, so there is no need for a guard (like if(!isLoaded){...})
  */
 function loadImports(){
+  /* import-globals-from modules/monkeypatch.js */
   Cu.import("resource://conversations/modules/monkeypatch.js", global);
   Cu.import("resource://conversations/modules/prefs.js", global);
+  /* import-globals-from modules/conversation.js */
   Cu.import("resource://conversations/modules/conversation.js", global);
+  /* import-globals-from modules/keycustomization.js */
   Cu.import("resource://conversations/modules/keycustomization.js", global);
 
   Cu.import("resource://conversations/modules/plugins/glodaAttrProviders.js");
@@ -167,8 +170,11 @@ let windowObserver = {
 
 function startup(aData, aReason) {
   ResourceRegister.init(aData.installPath, "conversations");
+  /* import-globals-from modules/log.js */
   Cu.import("resource://conversations/modules/log.js", global);
+  /* import-globals-from modules/prefs.js */
   Cu.import("resource://conversations/modules/prefs.js", global);
+  /* import-globals-from modules/config.js */
   Cu.import("resource://conversations/modules/config.js", global);
 
   Log = setupLogging("Conversations.MonkeyPatch");

--- a/content/.eslintrc.js
+++ b/content/.eslintrc.js
@@ -1,0 +1,9 @@
+"use strict";
+
+/* eslint-env node */
+
+module.exports = {
+  rules: {
+    "no-undef": "off"
+  }
+};

--- a/content/gallery/js/gallery.js
+++ b/content/gallery/js/gallery.js
@@ -43,8 +43,11 @@ const Cr = Components.results;
 
 Cu.import("resource:///modules/StringBundle.js"); // for StringBundle
 Cu.import("resource:///modules/gloda/mimemsg.js");
+/* import-globals-from ../../../modules/stdlib/msgHdrUtils.js */
 Cu.import("resource://conversations/modules/stdlib/msgHdrUtils.js");
+/* import-globals-from ../../../modules/stdlib/misc.js */
 Cu.import("resource://conversations/modules/stdlib/misc.js");
+/* import-globals-from ../../../modules/log.js */
 Cu.import("resource://conversations/modules/log.js");
 
 let Log = setupLogging("Conversations.Gallery");

--- a/defaults/preferences/defaults.js
+++ b/defaults/preferences/defaults.js
@@ -1,3 +1,4 @@
+/* global pref */
 pref("conversations.hide_quote_length", 5);
 pref("conversations.expand_who", 4); // kExpandAuto
 pref("conversations.monospaced_senders", "bugzilla-daemon@mozilla.org");

--- a/modules/assistant.js
+++ b/modules/assistant.js
@@ -16,14 +16,18 @@ const ioService = Cc["@mozilla.org/network/io-service;1"]
 const kPrefInt = 0, kPrefBool = 1, kPrefChar = 42;
 
 Cu.import("resource:///modules/MailUtils.js"); // for getFolderForURI
-Cu.import("resource:///modules/iteratorUtils.jsm"); // for fixIterator
-Cu.import("resource:///modules/virtualFolderWrapper.js");
+const {fixIterator} = Cu.import("resource:///modules/iteratorUtils.jsm", {});
+const {VirtualFolderHelper} = Cu.import("resource:///modules/virtualFolderWrapper.js", {});
 Cu.import("resource:///modules/gloda/index_msg.js");
 Cu.import("resource:///modules/gloda/public.js");
 
+/* import-globals-from stdlib/misc.js */
 Cu.import("resource://conversations/modules/stdlib/misc.js");
+/* import-globals-from stdlib/msgHdrUtils.js */
 Cu.import("resource://conversations/modules/stdlib/msgHdrUtils.js");
+/* import-globals-from prefs.js */
 Cu.import("resource://conversations/modules/prefs.js");
+/* import-globals-from log.js */
 Cu.import("resource://conversations/modules/log.js");
 
 let Log = setupLogging("Conversations.Assistant");

--- a/modules/contact.js
+++ b/modules/contact.js
@@ -44,17 +44,22 @@ const Cu = Components.utils;
 const Cr = Components.results;
 
 Cu.import("resource://gre/modules/Services.jsm"); // https://developer.mozilla.org/en/JavaScript_code_modules/Services.jsm
-Cu.import("resource:///modules/iteratorUtils.jsm"); // for fixIterator
+const {fixIterator} = Cu.import("resource:///modules/iteratorUtils.jsm", {}); // for fixIterator
 Cu.import("resource:///modules/StringBundle.js"); // for StringBundle
-Cu.import("resource:///modules/mailServices.js");
-Cu.import("resource:///modules/gloda/utils.js");
-Cu.import("resource:///modules/gloda/gloda.js");
+const {MailServices} = Cu.import("resource:///modules/mailServices.js", {});
+const {GlodaUtils} = Cu.import("resource:///modules/gloda/utils.js", {});
+const {Gloda} = Cu.import("resource:///modules/gloda/gloda.js", {});
 
+/* import-globals-from stdlib/compose.js */
 Cu.import("resource://conversations/modules/stdlib/compose.js");
+/* import-globals-from stdlib/misc.js */
 Cu.import("resource://conversations/modules/stdlib/misc.js");
 Cu.import("resource://conversations/modules/stdlib/msgHdrUtils.js");
+/* import-globals-from log.js */
 Cu.import("resource://conversations/modules/log.js");
+/* import-globals-from prefs.js */
 Cu.import("resource://conversations/modules/prefs.js");
+/* import-globals-from misc.js */
 Cu.import("resource://conversations/modules/misc.js");
 
 const clipboardService = Cc["@mozilla.org/widget/clipboardhelper;1"]

--- a/modules/conversation.js
+++ b/modules/conversation.js
@@ -46,12 +46,17 @@ const Cr = Components.results;
 Cu.import("resource://gre/modules/Services.jsm");
 
 Cu.import("resource:///modules/StringBundle.js"); // for StringBundle
-Cu.import("resource:///modules/gloda/gloda.js");
+const {Gloda} = Cu.import("resource:///modules/gloda/gloda.js", {});
+/* import-globals-from log.js */
 Cu.import("resource://conversations/modules/log.js");
+/* import-globals-from prefs.js */
 Cu.import("resource://conversations/modules/prefs.js");
 
+/* import-globals-from stdlib/msgHdrUtils.js */
 Cu.import("resource://conversations/modules/stdlib/msgHdrUtils.js");
+/* import-globals-from stdlib/misc.js */
 Cu.import("resource://conversations/modules/stdlib/misc.js");
+/* import-globals-from message.js */
 Cu.import("resource://conversations/modules/message.js");
 Cu.import("resource://conversations/modules/contact.js");
 Cu.import("resource://conversations/modules/misc.js"); // for groupArray

--- a/modules/keycustomization.js
+++ b/modules/keycustomization.js
@@ -44,8 +44,11 @@ const Cu = Components.utils;
 const Cr = Components.results;
 
 
+/* import-globals-from stdlib/misc.js */
 Cu.import("resource://conversations/modules/stdlib/misc.js");
+/* import-globals-from message.js */
 Cu.import("resource://conversations/modules/message.js");
+/* import-globals-from log.js */
 Cu.import("resource://conversations/modules/log.js");
 Cu.import("resource:///modules/StringBundle.js"); // for StringBundle
 let strings = new StringBundle("chrome://conversations/locale/keycustomization.properties");

--- a/modules/log.js
+++ b/modules/log.js
@@ -1,7 +1,8 @@
 var EXPORTED_SYMBOLS = ["setupLogging", "dumpCallStack", "logRoot", "Colors"]
 
+/* import-globals-from prefs.js */
 Components.utils.import("resource://conversations/modules/prefs.js");
-Components.utils.import("resource:///modules/gloda/log4moz.js");
+const {Log4Moz} = Components.utils.import("resource:///modules/gloda/log4moz.js", {});
 
 function setupLogging(name) {
   let Log = Log4Moz.repository.getLogger(name);
@@ -22,7 +23,7 @@ function setupLogging(name) {
 function setupFullLogging(name) {
   // dump(name+"\n\n");
   // The basic formatter will output lines like:
-  // DATE/TIME	LoggerName	LEVEL	(log message) 
+  // DATE/TIME	LoggerName	LEVEL	(log message)
   let formatter = new Log4Moz.BasicFormatter();
 
   let Log = Log4Moz.repository.getLogger(name);

--- a/modules/message.js
+++ b/modules/message.js
@@ -46,14 +46,16 @@ const Cr = Components.results;
 Cu.import("resource://gre/modules/XPCOMUtils.jsm"); // for generateQI
 Cu.import("resource://gre/modules/PluralForm.jsm");
 Cu.import("resource://gre/modules/Services.jsm"); // https://developer.mozilla.org/en/JavaScript_code_modules/Services.jsm
+/* import-globals-from stdlib/misc.js */
 Cu.import("resource://conversations/modules/stdlib/misc.js");
-Cu.import("resource:///modules/mailServices.js"); // bug 629462
-Cu.import("resource:///modules/StringBundle.js"); // for StringBundle
-Cu.import("resource:///modules/templateUtils.js"); // for makeFriendlyDateAgo
-Cu.import("resource:///modules/gloda/utils.js");
-Cu.import("resource:///modules/gloda/mimemsg.js");
-Cu.import("resource:///modules/gloda/connotent.js"); // for mimeMsgToContentSnippetAndMeta
+const {MailServices} = Cu.import("resource:///modules/mailServices.js", {}); // bug 629462
+Cu.import("resource:///modules/StringBundle.js");
+const {makeFriendlyDateAgo} = Cu.import("resource:///modules/templateUtils.js", {});
+const {GlodaUtils} = Cu.import("resource:///modules/gloda/utils.js", {});
+const {MsgHdrToMimeMessage} = Cu.import("resource:///modules/gloda/mimemsg.js", {});
+const {mimeMsgToContentSnippetAndMeta} = Cu.import("resource:///modules/gloda/connotent.js", {});
 
+/* import-globals-from plugins/lightning.js */
 Cu.import("resource://conversations/modules/plugins/lightning.js");
 // It's not really nice to write into someone elses object but this is what the
 // Services object is for.  We prefix with the "m" to ensure we stay out of their
@@ -78,16 +80,25 @@ const olderThan52 = Services.vc.compare(Services.sysinfo.version, "51.1") > 0;
 
 let strings = new StringBundle("chrome://conversations/locale/message.properties");
 
+/* import-globals-from stdlib/addressBookUtils.js */
 Cu.import("resource://conversations/modules/stdlib/addressBookUtils.js");
+/* import-globals-from stdlib/msgHdrUtils.js */
 Cu.import("resource://conversations/modules/stdlib/msgHdrUtils.js");
+/* import-globals-from stdlib/compose.js */
 Cu.import("resource://conversations/modules/stdlib/compose.js");
-Cu.import("resource://conversations/modules/stdlib/misc.js");
+/* import-globals-from plugins/helpers.js */
 Cu.import("resource://conversations/modules/plugins/helpers.js");
+/* import-globals-from quoting.js */
 Cu.import("resource://conversations/modules/quoting.js");
+/* import-globals-from contact.js */
 Cu.import("resource://conversations/modules/contact.js");
+/* import-globals-from prefs.js */
 Cu.import("resource://conversations/modules/prefs.js");
+/* import-globals-from misc.js */
 Cu.import("resource://conversations/modules/misc.js"); // for iconForMimeType
+/* import-globals-from hook.js */
 Cu.import("resource://conversations/modules/hook.js");
+/* import-globals-from log.js */
 Cu.import("resource://conversations/modules/log.js");
 
 let Log = setupLogging("Conversations.Message");

--- a/modules/misc.js
+++ b/modules/misc.js
@@ -48,10 +48,14 @@ const Cc = Components.classes;
 const Cu = Components.utils;
 
 Cu.import("resource:///modules/StringBundle.js"); // for StringBundle
-Cu.import("resource:///modules/gloda/index_msg.js");
+const { GlodaMsgIndexer } = Cu.import("resource:///modules/gloda/index_msg.js", {});
+/* import-globals-from stdlib/misc.js */
 Cu.import("resource://conversations/modules/stdlib/misc.js");
+/* import-globals-from stdlib/msgHdrUtils.js */
 Cu.import("resource://conversations/modules/stdlib/msgHdrUtils.js");
+/* import-globals-from prefs.js */
 Cu.import("resource://conversations/modules/prefs.js");
+/* import-globals-from log.js */
 Cu.import("resource://conversations/modules/log.js");
 
 let Log = setupLogging("Conversations.Misc");

--- a/modules/monkeypatch.js
+++ b/modules/monkeypatch.js
@@ -46,12 +46,19 @@ const Cr = Components.results;
 Cu.import("resource://gre/modules/AddonManager.jsm");
 Cu.import("resource:///modules/StringBundle.js"); // for StringBundle
 
+/* import-globals-from stdlib/misc.js */
 Cu.import("resource://conversations/modules/stdlib/misc.js");
+/* import-globals-from stdlib/msgHdrUtils.js */
 Cu.import("resource://conversations/modules/stdlib/msgHdrUtils.js");
+/* import-globals-from assistant.js */
 Cu.import("resource://conversations/modules/assistant.js");
+/* import-globals-from misc.js */
 Cu.import("resource://conversations/modules/misc.js"); // for joinWordList, openConversationIn
+/* import-globals-from prefs.js */
 Cu.import("resource://conversations/modules/prefs.js");
+/* import-globals-from log.js */
 Cu.import("resource://conversations/modules/log.js");
+/* import-globals-from config.js */
 Cu.import("resource://conversations/modules/config.js");
 
 Cu.import("resource://gre/modules/Services.jsm");

--- a/modules/plugins/embeds.js
+++ b/modules/plugins/embeds.js
@@ -45,9 +45,13 @@ Cu.import("resource://gre/modules/Services.jsm"); // https://developer.mozilla.o
 Cu.import("resource:///modules/StringBundle.js"); // for StringBundle
 Cu.import("resource://conversations/modules/stdlib/msgHdrUtils.js");
 Cu.import("resource://conversations/modules/stdlib/misc.js");
+/* import-globals-from ../prefs.js */
 Cu.import("resource://conversations/modules/prefs.js");
+/* import-globals-from ../misc.js */
 Cu.import("resource://conversations/modules/misc.js");
+/* import-globals-from ../hook.js */
 Cu.import("resource://conversations/modules/hook.js");
+/* import-globals-from ../log.js */
 Cu.import("resource://conversations/modules/log.js");
 
 let strings = new StringBundle("chrome://conversations/locale/message.properties");

--- a/modules/plugins/enigmail.js
+++ b/modules/plugins/enigmail.js
@@ -71,11 +71,17 @@ const Cr = Components.results;
 
 Cu.import("resource://gre/modules/Services.jsm"); // https://developer.mozilla.org/en/JavaScript_code_modules/Services.jsm
 Cu.import("resource:///modules/StringBundle.js"); // for StringBundle
+/* import-globals-from ../stdlib/msgHdrUtils.js */
 Cu.import("resource://conversations/modules/stdlib/msgHdrUtils.js");
+/* import-globals-from ../stdlib/misc.js */
 Cu.import("resource://conversations/modules/stdlib/misc.js");
+/* import-globals-from ../stdlib/compose.js */
 Cu.import("resource://conversations/modules/stdlib/compose.js");
+/* import-globals-from ../misc.js */
 Cu.import("resource://conversations/modules/misc.js");
+/* import-globals-from ../hook.js */
 Cu.import("resource://conversations/modules/hook.js");
+/* import-globals-from ../log.js */
 Cu.import("resource://conversations/modules/log.js");
 
 let strings = new StringBundle("chrome://conversations/locale/message.properties");
@@ -93,6 +99,9 @@ let Log = setupLogging("Conversations.Modules.Enigmail");
 let window = getMail3Pane();
 let hasEnigmail;
 try {
+  /* globals EnigmailCommon, EnigmailCore, EnigmailData, EnigmailLocale,
+             EnigmailFuncs, Enigmail, EnigmailPrefs, EnigmailDialog,
+             EnigmailConstants, EnigmailRules */
   Cu.import("resource://enigmail/core.jsm");
   Cu.import("resource://enigmail/data.jsm");
   Cu.import("resource://enigmail/dialog.jsm");
@@ -526,7 +535,7 @@ function patchForShowSecurityInfo(aWindow) {
     w.top.controllers.getControllerForCommand("button_enigmail_decrypt");
   w.top.controllers.removeController(oldTreeController);
   let treeController = {};
-  for ([i, x] of entries(oldTreeController)) {
+  for (let [i, x] of entries(oldTreeController)) {
     treeController[i] = x;
   }
   treeController.isCommandEnabled = function () {

--- a/modules/plugins/glodaAttrProviders.js
+++ b/modules/plugins/glodaAttrProviders.js
@@ -67,8 +67,9 @@ const Cc = Components.classes;
 const Cu = Components.utils;
 const Cr = Components.results;
 
+/* import-globals-from helpers.js */
 Cu.import("resource://conversations/modules/plugins/helpers.js");
-Cu.import("resource:///modules/gloda/public.js");
+const {Gloda} = Cu.import("resource:///modules/gloda/public.js", {});
 Cu.import("resource:///modules/gloda/mimemsg.js");
 
 let AlternativeSender = {

--- a/modules/plugins/helpers.js
+++ b/modules/plugins/helpers.js
@@ -43,7 +43,7 @@ var EXPORTED_SYMBOLS = ['PluginHelpers']
  *  gloda yet (see message.js).
  */
 
-Components.utils.import("resource:///modules/gloda/utils.js");
+const {GlodaUtils} = Components.utils.import("resource:///modules/gloda/utils.js", {});
 Components.utils.import("resource://conversations/modules/stdlib/misc.js");
 
 const gsfnRegexp = /^(.+)(?:, an employee of Mozilla Messaging,)? (?:replied to|commented on|just asked)/;

--- a/modules/plugins/lightning.js
+++ b/modules/plugins/lightning.js
@@ -36,8 +36,11 @@
 
 var EXPORTED_SYMBOLS = ["isLightningInstalled"];
 
+/* import-globals-from ../hook.js */
 Components.utils.import("resource://conversations/modules/hook.js");
+/* import-globals-from ../log.js */
 Components.utils.import("resource://conversations/modules/log.js");
+/* import-globals-from ../misc.js */
 Components.utils.import("resource://conversations/modules/misc.js");
 Components.utils.import("resource://gre/modules/Services.jsm");
 
@@ -48,8 +51,9 @@ function isLightningInstalled() {
 };
 
 let hasLightning = false;
+let cal;
 try {
-  Components.utils.import("resource://calendar/modules/calItipUtils.jsm");
+  cal = Components.utils.import("resource://calendar/modules/calItipUtils.jsm", {});
   if (cal.itip.getMethodText) {
     // We need the patch from mozilla bug 626829 for this plugin to work. The
     // patch adds the method cal.itip.getMethodText.

--- a/modules/prefs.js
+++ b/modules/prefs.js
@@ -126,7 +126,7 @@ PrefManager.prototype = {
 
       case "monospaced_senders":
         this.monospaced_senders = {};
-        for (s of this.split(prefsService.getCharPref("monospaced_senders")))
+        for (let s of this.split(prefsService.getCharPref("monospaced_senders")))
           this.monospaced_senders[s] = null;
         break;
     }

--- a/modules/quoting.js
+++ b/modules/quoting.js
@@ -226,7 +226,7 @@ function fusionBlockquotes(aDoc) {
         blockquote.parentNode.removeChild(next);
         blockquotes.delete(next);
       } else {
-        Log.error("What?!");
+        Cu.reportError("What?!");
       }
     }
   }

--- a/other/oembed-addon/bootstrap.js
+++ b/other/oembed-addon/bootstrap.js
@@ -43,7 +43,7 @@ const Cr = Components.results;
 
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 Cu.import("resource://gre/modules/Services.jsm");
-Cu.import("resource:///modules/iteratorUtils.jsm");
+const {fixIterator} = Cu.import("resource:///modules/iteratorUtils.jsm", {});
 
 let global = this;
 let Log;
@@ -62,7 +62,7 @@ let hook = {
     let iframeDoc = iframe.contentDocument;
     let links = iframeDoc.getElementsByTagName("a");
     // Don't detect links in quotations.
-    for (x of iframe.querySelectorAll("blockquote a")) {
+    for (let x of iframe.querySelectorAll("blockquote a")) {
       x.skip = true;
     }
     let seen = {};
@@ -151,9 +151,13 @@ function doStuff() {
     return;
 
   try {
+    /* import-globals-from ../../modules/stdlib/msgHdrUtils.js */
     Cu.import("resource://conversations/modules/stdlib/msgHdrUtils.js", global);
+    /* import-globals-from ../../modules/hook.js */
     Cu.import("resource://conversations/modules/hook.js", global);
+    /* import-globals-from ../../modules/prefs.js */
     Cu.import("resource://conversations/modules/prefs.js", global);
+    /* import-globals-from ../../modules/log.js */
     Cu.import("resource://conversations/modules/log.js", global);
 
     Log = setupLogging("Conversations.OEmbed");


### PR DESCRIPTION
This enables the no-undef rule for everything apart from content/. I think it may be possible to clean up some of the imports further, but we'll see to that later.

Additionally note that as eslint-plugin-mozilla doesn't support Thunderbird's modules, I'm changing the style of import to be explicit variables.