### PR TITLE
Clean up some deprecated APIs usage

### DIFF
--- a/content/handlebars-wrapper.js
+++ b/content/handlebars-wrapper.js
@@ -83,7 +83,7 @@ function wrapHandlebars() {
     return new Handlebars.SafeString(tmpl0(id, data));
   };
   let trim = function (s) {
-    return String.trim(s || "");
+    return String.prototype.trim.call(s || "");
   };
 
   Handlebars.registerHelper("str", str);

--- a/content/stub.completion-ui.js
+++ b/content/stub.completion-ui.js
@@ -31,7 +31,7 @@ try {
 // Wrap the given parameters in an object that's compatible with the
 //  facebook-style autocomplete.
 function asToken(thumb, name, email, guid) {
-  let hasName = name && (String.trim(name).length > 0);
+  let hasName = name && (name.trim().length > 0);
   let data = hasName ? MailServices.headerParser.makeMimeAddress(name, email) : email;
   let nameStr = hasName ? name + " <" + email + ">" : email;
   let thumbStr = thumb ? "<img class='autocomplete-thumb' src=\""+escapeHtml(thumb)+"\" /> " : "";

--- a/content/stub.xhtml
+++ b/content/stub.xhtml
@@ -296,7 +296,7 @@
     $(document).ready(function () {
       let stylesheet;
       for (let x of document.styleSheets) {
-        if (String.indexOf(x.href, "/conversation.css") >= 0) {
+        if (x.href.indexOf("/conversation.css") >= 0) {
           stylesheet = x;
           break;
         }

--- a/modules/message.js
+++ b/modules/message.js
@@ -478,10 +478,10 @@ Message.prototype = {
           items.push(key+": "+makeArrow(oldInfos[k], infos[k]));
         }
       }
-      if (infos["changed-fields"] && String.trim(infos["changed-fields"]).length)
+      if (infos["changed-fields"] && infos["changed-fields"].trim().length)
         items.push("Changed: "+infos["changed-fields"]);
       let m = this._snippet.match(this.RE_BZ_COMMENT);
-      if (m && m.length && String.trim(m[1]).length)
+      if (m && m.length && m[1].trim().length)
         items.push(m[1]);
       if (!items.length)
         items.push(this._snippet);
@@ -864,10 +864,10 @@ Message.prototype = {
     // Pre-set the right value
     let realFrom = "";
     if (this._from.email)
-      realFrom = String.trim(this._from.email).toLowerCase();
+      realFrom = this._from.email.trim().toLowerCase();
     // _realFrom is better.
     if (this._realFrom.email)
-      realFrom = String.trim(this._realFrom.email).toLowerCase();
+      realFrom = this._realFrom.email.trim().toLowerCase();
     if (realFrom in Prefs["monospaced_senders"])
       this._domNode.getElementsByClassName("checkbox-monospace")[0].checked = true;
 

--- a/modules/misc.js
+++ b/modules/misc.js
@@ -270,13 +270,13 @@ function reindexMessages(aMsgHdrs) {
 }
 
 function folderName(aFolder) {
-  let folderStr = aFolder.prettiestName;
+  let folderStr = aFolder.prettyName;
   let folder = aFolder;
   while (folder.parent) {
     folder = folder.parent;
     folderStr = folder.name + "/" + folderStr;
   }
-  return [aFolder.prettiestName, folderStr];
+  return [aFolder.prettyName, folderStr];
 }
 
 function openConversationInTabOrWindow(aUrl) {

--- a/modules/prefs.js
+++ b/modules/prefs.js
@@ -77,7 +77,7 @@ function PrefManager() {
 
 PrefManager.prototype = {
 
-  split: s => Array.map(s.split(","), String.trim).filter(String.trim).map(String.toLowerCase),
+  split: s => s.split(",").map(s => s.trim()).map(s => s.toLowerCase()),
 
   watch: function (watcher) { return this.watchers.push(watcher); },
 

--- a/modules/quoting.js
+++ b/modules/quoting.js
@@ -60,7 +60,7 @@ function insertAfter(newElement, referenceElt) {
 
 function canInclude(aNode) {
   let v = aNode.tagName && aNode.tagName.toLowerCase() == "br"
-    || aNode.nodeType == aNode.TEXT_NODE && String.trim(aNode.textContent) === "";
+    || aNode.nodeType == aNode.TEXT_NODE && aNode.textContent.trim() === "";
   //if (v) dump("Including "+aNode+"\n");
   return v;
 }


### PR DESCRIPTION
String.x is deprecated: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Deprecated_String_generics

Also folder.prettiestName is reporting as deprecated as well.

There's still others to fix, but we can leave those for later.

@protz please can you look over this, especially the String.* changes.