### PR TITLE
Update Outlook blockquote detection for newer versions

### DIFF
--- a/modules/quoting.js
+++ b/modules/quoting.js
@@ -135,7 +135,8 @@ function convertOutlookQuotingToBlockquote(aWin, aDoc) {
   trySel(aDoc, ".OutlookMessageHeader");
   for (let div of aDoc.getElementsByTagName("div")) {
     let style = aWin.getComputedStyle(div, null);
-    if (style.borderTopColor == "rgb(181, 196, 223)"
+    if ((style.borderTopColor == "rgb(181, 196, 223)"
+         || style.borderTopColor == "rgb(225, 225, 225)")
         && style.borderTopStyle == "solid"
         && style.borderLeftWidth == "0px"
         && style.borderRightWidth == "0px"


### PR DESCRIPTION
Based on my painful inbox, newer outlook versions slightly changed the shade of this horizontal line, so we need to refine the check a little.

The HTML still looks entirely generic with nothing better to select against, though.