### PR TITLE
Adopt decryption to API of Enigmail 2.0

### DIFF
--- a/modules/plugins/enigmail.js
+++ b/modules/plugins/enigmail.js
@@ -460,11 +460,7 @@ function verifyAttachments(aMessage) {
   let { _attachments: attachments, _uri: uri, contentType: contentType } = aMessage;
   let w = topMail3Pane(aMessage);
   if ((contentType+"").search(/^multipart\/signed(;|$)/i) == 0) {
-    w.Enigmail.msg.messageDecryptCb(null, true, {
-      headers: {'content-type': contentType },
-      contentType,
-      parts: null,
-    });
+    w.Enigmail.msg.messageDecryptCb(null, true, null);
     return;
   }
   if ((contentType+"").search(/^multipart\/mixed(;|$)/i) != 0)


### PR DESCRIPTION
The API for Engimail.msg.messageDecryptCb has changed with Enigmail v2.0. This patch adopts to the change (and fixes the Enigmail bug https://sourceforge.net/p/enigmail/bugs/894/).