### PR TITLE
Change Babel configuration to work for just Firefox 68 or later, since that is what we currently support.

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -5,7 +5,10 @@ module.exports = function(api) {
     [
       "@babel/preset-env",
       // We don't want es modules to be bundled; we'll use native loading!
-      { targets: { esmodules: true }, modules: false },
+      {
+        targets: { browsers: "Firefox >= 68.0" },
+        modules: false,
+      },
     ],
     [
       "@babel/preset-react",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "type": "git",
     "url": "git@github.com:protz/thunderbird-conversations.git"
   },
-  "browserslist": "Firefox > 68",
   "bugs": {
     "url": "https://github.com/protz/thunderbird-conversations/issues"
   },


### PR DESCRIPTION
The 'esmodules' definition equates to Firefox 60 or later, [see here](https://github.com/babel/babel/blob/9febf6388233c3d23d4fa9deca5ca8f682567573/packages/babel-preset-env/data/built-in-modules.json).

This currently means the generated code has changes such as async/await swapped into generators, arrow functions replaced and more.

Whilst this probably doesn't matter too much, I think I'd rather keep the changes minimal and let the generated code use all the features of js that are available in the minimum version that we support (68). There's would be a slight reduction in file size, maybe some very small performance advantages as well (due to not having polyfill functions).

@siefkenj can you see any reason not to do this?