### PR TITLE
Create a browser mapping for stub.xhtml to use to simulate WebExtensions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,6 +30,13 @@ module.exports = {
         sourceType: "module",
       },
     },
+    {
+      env: {
+        webextensions: true,
+      },
+      excludedFiles: ["addon/content/modules/**/*.js"],
+      files: ["addon/content/**/*.js", "addon/content/**/*.jsx"],
+    },
   ],
   plugins: ["mozilla", "html", "react"],
   rules: {

--- a/addon/_locales/bg/messages.json
+++ b/addon/_locales/bg/messages.json
@@ -232,5 +232,10 @@
   "gallery.title": {
     "message": "Изглед „галерия“ за: $1",
     "description": "The tab title for the image gallery"
+  },
+
+  "options.start_setup_assistant": {
+    "message": "Стартиране на помощника",
+    "description": "Title of the button to open the setup assistant."
   }
 }

--- a/addon/_locales/ca/messages.json
+++ b/addon/_locales/ca/messages.json
@@ -232,5 +232,10 @@
   "gallery.title": {
     "message": "Vista de la galeria per :$1",
     "description": "The tab title for the image gallery"
+  },
+
+  "options.start_setup_assistant": {
+    "message": "Engega  l'Assistent de configuració",
+    "description": "Title of the button to open the setup assistant."
   }
 }

--- a/addon/_locales/cs/messages.json
+++ b/addon/_locales/cs/messages.json
@@ -232,5 +232,10 @@
   "gallery.title": {
     "message": "Všechny obrázky ze zprávy: $1",
     "description": "The tab title for the image gallery"
+  },
+
+  "options.start_setup_assistant": {
+    "message": "Spustit pomocníka s nastavením",
+    "description": "Title of the button to open the setup assistant."
   }
 }

--- a/addon/_locales/da/messages.json
+++ b/addon/_locales/da/messages.json
@@ -232,5 +232,10 @@
   "gallery.title": {
     "message": "Galleri visning for: $1",
     "description": "The tab title for the image gallery"
+  },
+
+  "options.start_setup_assistant": {
+    "message": "Start opsætningsassistenten",
+    "description": "Title of the button to open the setup assistant."
   }
 }

--- a/addon/_locales/de/messages.json
+++ b/addon/_locales/de/messages.json
@@ -232,5 +232,10 @@
   "gallery.title": {
     "message": "Galerieansicht für: $1",
     "description": "The tab title for the image gallery"
+  },
+
+  "options.start_setup_assistant": {
+    "message": "Installationsassistenten starten",
+    "description": "Title of the button to open the setup assistant."
   }
 }

--- a/addon/_locales/el/messages.json
+++ b/addon/_locales/el/messages.json
@@ -232,5 +232,10 @@
   "gallery.title": {
     "message": "Προβολή συλλογής για: $1",
     "description": "The tab title for the image gallery"
+  },
+
+  "options.start_setup_assistant": {
+    "message": "Εκκίνηση του βοηθού ρυθμίσεων",
+    "description": "Title of the button to open the setup assistant."
   }
 }

--- a/addon/_locales/en/messages.json
+++ b/addon/_locales/en/messages.json
@@ -232,5 +232,10 @@
   "gallery.title": {
     "message": "Gallery view for : $1",
     "description": "The tab title for the image gallery"
+  },
+
+  "options.start_setup_assistant": {
+    "message": "Start the setup assistant",
+    "description": "Title of the button to open the setup assistant."
   }
 }

--- a/addon/_locales/es/messages.json
+++ b/addon/_locales/es/messages.json
@@ -232,5 +232,10 @@
   "gallery.title": {
     "message": "Vista de galería para: $1",
     "description": "The tab title for the image gallery"
+  },
+
+  "options.start_setup_assistant": {
+    "message": "Iniciar el asistente de configuración",
+    "description": "Title of the button to open the setup assistant."
   }
 }

--- a/addon/_locales/eu/messages.json
+++ b/addon/_locales/eu/messages.json
@@ -232,5 +232,10 @@
   "gallery.title": {
     "message": "Galeria ikuspegia: $1",
     "description": "The tab title for the image gallery"
+  },
+
+  "options.start_setup_assistant": {
+    "message": "Hasi konfigurazio-laguntzailea",
+    "description": "Title of the button to open the setup assistant."
   }
 }

--- a/addon/_locales/fi/messages.json
+++ b/addon/_locales/fi/messages.json
@@ -232,5 +232,10 @@
   "gallery.title": {
     "message": "Galleria näkymä:$1",
     "description": "The tab title for the image gallery"
+  },
+
+  "options.start_setup_assistant": {
+    "message": "Aloita asennusvelho",
+    "description": "Title of the button to open the setup assistant."
   }
 }

--- a/addon/_locales/fr/messages.json
+++ b/addon/_locales/fr/messages.json
@@ -232,5 +232,10 @@
   "gallery.title": {
     "message": "Vue en galerie pour : $1",
     "description": "The tab title for the image gallery"
+  },
+
+  "options.start_setup_assistant": {
+    "message": "Lancer l'assistant d'installation",
+    "description": "Title of the button to open the setup assistant."
   }
 }

--- a/addon/_locales/gl/messages.json
+++ b/addon/_locales/gl/messages.json
@@ -232,5 +232,10 @@
   "gallery.title": {
     "message": "Vista da galería de: $1",
     "description": "The tab title for the image gallery"
+  },
+
+  "options.start_setup_assistant": {
+    "message": "Iniciar o asistente de configuración",
+    "description": "Title of the button to open the setup assistant."
   }
 }

--- a/addon/_locales/he-IL/messages.json
+++ b/addon/_locales/he-IL/messages.json
@@ -232,5 +232,10 @@
   "gallery.title": {
     "message": "תצוגת אלבום עבור: $1‏",
     "description": "The tab title for the image gallery"
+  },
+
+  "options.start_setup_assistant": {
+    "message": "התחל את אשף ההתקנה",
+    "description": "Title of the button to open the setup assistant."
   }
 }

--- a/addon/_locales/hr/messages.json
+++ b/addon/_locales/hr/messages.json
@@ -232,5 +232,10 @@
   "gallery.title": {
     "message": "Prikaz galerije za: $1",
     "description": "The tab title for the image gallery"
+  },
+
+  "options.start_setup_assistant": {
+    "message": "Pokreni čarobnjaka za postavke",
+    "description": "Title of the button to open the setup assistant."
   }
 }

--- a/addon/_locales/it/messages.json
+++ b/addon/_locales/it/messages.json
@@ -232,5 +232,10 @@
   "gallery.title": {
     "message": "Visualizzazione a galleria per $1",
     "description": "The tab title for the image gallery"
+  },
+
+  "options.start_setup_assistant": {
+    "message": "Avvia la configurazione guidata",
+    "description": "Title of the button to open the setup assistant."
   }
 }

--- a/addon/_locales/ja-JP/messages.json
+++ b/addon/_locales/ja-JP/messages.json
@@ -232,5 +232,10 @@
   "gallery.title": {
     "message": "ギャラリー表示: $1",
     "description": "The tab title for the image gallery"
+  },
+
+  "options.start_setup_assistant": {
+    "message": "設定アシスタントを起動する",
+    "description": "Title of the button to open the setup assistant."
   }
 }

--- a/addon/_locales/lt/messages.json
+++ b/addon/_locales/lt/messages.json
@@ -232,5 +232,10 @@
   "gallery.title": {
     "message": "Galerijos peržiūra: $1",
     "description": "The tab title for the image gallery"
+  },
+
+  "options.start_setup_assistant": {
+    "message": "Paleisti nustatymo padėjėją",
+    "description": "Title of the button to open the setup assistant."
   }
 }

--- a/addon/_locales/nl/messages.json
+++ b/addon/_locales/nl/messages.json
@@ -232,5 +232,10 @@
   "gallery.title": {
     "message": "Galerijweergave voor: $1",
     "description": "The tab title for the image gallery"
+  },
+
+  "options.start_setup_assistant": {
+    "message": "Start de instelassistent",
+    "description": "Title of the button to open the setup assistant."
   }
 }

--- a/addon/_locales/pl/messages.json
+++ b/addon/_locales/pl/messages.json
@@ -232,5 +232,10 @@
   "gallery.title": {
     "message": "Widok galerii $1",
     "description": "The tab title for the image gallery"
+  },
+
+  "options.start_setup_assistant": {
+    "message": "Uruchom asystenta konfiguracji",
+    "description": "Title of the button to open the setup assistant."
   }
 }

--- a/addon/_locales/pt-BR/messages.json
+++ b/addon/_locales/pt-BR/messages.json
@@ -232,5 +232,10 @@
   "gallery.title": {
     "message": "Modo galeria para: $1",
     "description": "The tab title for the image gallery"
+  },
+
+  "options.start_setup_assistant": {
+    "message": "Iniciar assistente de instalação",
+    "description": "Title of the button to open the setup assistant."
   }
 }

--- a/addon/_locales/rm/messages.json
+++ b/addon/_locales/rm/messages.json
@@ -232,5 +232,10 @@
   "gallery.title": {
     "message": "Vista da galaria per: $1",
     "description": "The tab title for the image gallery"
+  },
+
+  "options.start_setup_assistant": {
+    "message": "Aviar l'assistent d'installaziun",
+    "description": "Title of the button to open the setup assistant."
   }
 }

--- a/addon/_locales/ru-RU/messages.json
+++ b/addon/_locales/ru-RU/messages.json
@@ -232,5 +232,10 @@
   "gallery.title": {
     "message": "Галерея для: $1",
     "description": "The tab title for the image gallery"
+  },
+
+  "options.start_setup_assistant": {
+    "message": "Запустить помощник настройки",
+    "description": "Title of the button to open the setup assistant."
   }
 }

--- a/addon/_locales/sl/messages.json
+++ b/addon/_locales/sl/messages.json
@@ -232,5 +232,10 @@
   "gallery.title": {
     "message": "Galerijski pogled za: $1",
     "description": "The tab title for the image gallery"
+  },
+
+  "options.start_setup_assistant": {
+    "message": "Zaženi pomočnika za nastavitev",
+    "description": "Title of the button to open the setup assistant."
   }
 }

--- a/addon/_locales/sr/messages.json
+++ b/addon/_locales/sr/messages.json
@@ -232,5 +232,10 @@
   "gallery.title": {
     "message": "Приказ галерије за: $1",
     "description": "The tab title for the image gallery"
+  },
+
+  "options.start_setup_assistant": {
+    "message": "Покрени помоћника за подешавање",
+    "description": "Title of the button to open the setup assistant."
   }
 }

--- a/addon/_locales/sv-SE/messages.json
+++ b/addon/_locales/sv-SE/messages.json
@@ -232,5 +232,10 @@
   "gallery.title": {
     "message": "Gallerivy för: $1",
     "description": "The tab title for the image gallery"
+  },
+
+  "options.start_setup_assistant": {
+    "message": "Starta konfigurationsguiden",
+    "description": "Title of the button to open the setup assistant."
   }
 }

--- a/addon/_locales/tr/messages.json
+++ b/addon/_locales/tr/messages.json
@@ -232,5 +232,10 @@
   "gallery.title": {
     "message": "Galeri görünümü: $1",
     "description": "The tab title for the image gallery"
+  },
+
+  "options.start_setup_assistant": {
+    "message": "Kurulum Yardımcısı'nı başlat",
+    "description": "Title of the button to open the setup assistant."
   }
 }

--- a/addon/_locales/zh-CN/messages.json
+++ b/addon/_locales/zh-CN/messages.json
@@ -232,5 +232,10 @@
   "gallery.title": {
     "message": "画廊视图: $1",
     "description": "The tab title for the image gallery"
+  },
+
+  "options.start_setup_assistant": {
+    "message": "启动安装助手",
+    "description": "Title of the button to open the setup assistant."
   }
 }

--- a/addon/_locales/zh-TW/messages.json
+++ b/addon/_locales/zh-TW/messages.json
@@ -232,5 +232,10 @@
   "gallery.title": {
     "message": "畫廊視圖: $1",
     "description": "The tab title for the image gallery"
+  },
+
+  "options.start_setup_assistant": {
+    "message": "啟動安裝助手",
+    "description": "Title of the button to open the setup assistant."
   }
 }

--- a/addon/background.js
+++ b/addon/background.js
@@ -13,11 +13,12 @@ class Background {
     await this._prefs.init();
     await this._keyHandler.init();
 
-    browser.conversations.onOpenTab.addListener(url => {
-      browser.tabs.create({
-        url,
-      });
-    });
+    // Setup the temporary API caller that stub.xhtml uses.
+    browser.conversations.onCallAPI.addListener(
+      async (apiName, apiItem, args) => {
+        return browser[apiName][apiItem](...args);
+      }
+    );
   }
 }
 

--- a/addon/content/es-modules/thunderbird-compat.js
+++ b/addon/content/es-modules/thunderbird-compat.js
@@ -85,4 +85,10 @@ if (!browser.storage) {
   };
 }
 
+if (!browser.tabs) {
+  browser.tabs = {
+    create() {},
+  };
+}
+
 export { browser };

--- a/addon/content/message.jsx
+++ b/addon/content/message.jsx
@@ -142,7 +142,7 @@ class Message extends React.PureComponent {
       case "a":
         this.props.dispatch({
           type: "MSG_ARCHIVE",
-          msgUri: this.props.message.msgUri,
+          id: this.props.message.id,
         });
         break;
       case "o":
@@ -162,7 +162,7 @@ class Message extends React.PureComponent {
       case "9":
         this.props.dispatch({
           type: "MSG_TOGGLE_TAG_BY_INDEX",
-          msgUri: this.props.message.msgUri,
+          id: this.props.message.id,
           tags: this.props.message.tags,
           // Tag indexes start at 0
           index: +shortcut - 1,
@@ -173,7 +173,7 @@ class Message extends React.PureComponent {
         // Remove all tags
         this.props.dispatch({
           type: "MSG_SET_TAGS",
-          msgUri: this.props.message.msgUri,
+          id: this.props.message.id,
           tags: [],
         });
         stopEvent();
@@ -245,6 +245,7 @@ class Message extends React.PureComponent {
           from={this.props.message.from}
           to={this.props.message.to}
           fullDate={this.props.message.fullDate}
+          id={this.props.message.id}
           msgUri={this.props.message.msgUri}
           attachments={this.props.message.attachments}
           multipleRecipients={this.props.message.multipleRecipients}
@@ -310,7 +311,7 @@ class Message extends React.PureComponent {
               onTagsChange={tags => {
                 this.props.dispatch({
                   type: "MSG_SET_TAGS",
-                  msgUri: this.props.message.msgUri,
+                  id: this.props.message.id,
                   tags,
                 });
               }}

--- a/addon/content/messageFooter.jsx
+++ b/addon/content/messageFooter.jsx
@@ -13,6 +13,7 @@ class MessageFooter extends React.PureComponent {
 
   action(msg) {
     msg.msgUri = this.props.msgUri;
+    msg.id = this.props.id;
     this.props.dispatch(msg);
   }
 
@@ -43,6 +44,7 @@ class MessageFooter extends React.PureComponent {
 
 MessageFooter.propTypes = {
   dispatch: PropTypes.func.isRequired,
+  id: PropTypes.number.isRequired,
   msgUri: PropTypes.string.isRequired,
   multipleRecipients: PropTypes.bool.isRequired,
   recipientsIncludeLists: PropTypes.bool.isRequired,

--- a/addon/content/messageHeader.jsx
+++ b/addon/content/messageHeader.jsx
@@ -220,7 +220,7 @@ class MessageHeader extends React.PureComponent {
     event.preventDefault();
     this.props.dispatch({
       type: "MSG_STAR",
-      msgUri: this.props.msgUri,
+      id: this.props.id,
       star: !this.props.starred,
     });
   }
@@ -300,7 +300,7 @@ class MessageHeader extends React.PureComponent {
                 onTagsChange={tags => {
                   this.props.dispatch({
                     type: "MSG_SET_TAGS",
-                    msgUri: this.props.msgUri,
+                    id: this.props.id,
                     tags,
                   });
                 }}
@@ -331,6 +331,7 @@ class MessageHeader extends React.PureComponent {
           detailsShowing={this.props.detailsShowing}
           expanded={this.props.expanded}
           fullDate={this.props.fullDate}
+          id={this.props.id}
           msgUri={this.props.msgUri}
           attachments={this.props.attachments}
           multipleRecipients={this.props.multipleRecipients}
@@ -351,6 +352,7 @@ MessageHeader.propTypes = {
   expanded: PropTypes.bool.isRequired,
   from: PropTypes.object.isRequired,
   fullDate: PropTypes.string.isRequired,
+  id: PropTypes.number.isRequired,
   msgUri: PropTypes.string.isRequired,
   attachments: PropTypes.array.isRequired,
   multipleRecipients: PropTypes.bool.isRequired,

--- a/addon/content/messageHeaderOptions.jsx
+++ b/addon/content/messageHeaderOptions.jsx
@@ -136,6 +136,7 @@ class MessageHeaderOptions extends React.PureComponent {
     event.preventDefault();
     this.props.dispatch({
       ...msg,
+      id: this.props.id,
       msgUri: this.props.msgUri,
     });
   }
@@ -290,6 +291,7 @@ MessageHeaderOptions.propTypes = {
   detailsShowing: PropTypes.bool.isRequired,
   expanded: PropTypes.bool.isRequired,
   fullDate: PropTypes.string.isRequired,
+  id: PropTypes.number.isRequired,
   msgUri: PropTypes.string.isRequired,
   attachments: PropTypes.array.isRequired,
   multipleRecipients: PropTypes.bool.isRequired,

--- a/addon/content/modules/contact.js
+++ b/addon/content/modules/contact.js
@@ -96,45 +96,6 @@ function getInitials(name) {
 }
 
 var ContactHelpers = {
-  addContact(win, name, email) {
-    let cardAndBook = DisplayNameUtils.getCardForEmail(email);
-    let args = {
-      primaryEmail: email,
-      displayName: name,
-      allowRemoteContent: true,
-      // This is too messed up, there's no easy way to interact with this
-      //  dialog, just forget about it. RegisterSaveListener seems to be
-      //  uncallable... and okCallback just short-circuit the whole logic
-    };
-    win.openDialog(
-      "chrome://messenger/content/addressbook/abNewCardDialog.xul",
-      "",
-      "chrome,resizable=no,titlebar,modal,centerscreen",
-      args
-    );
-    // This is an approximation, but it should be good enough
-    let newCardAndBook = DisplayNameUtils.getCardForEmail(email);
-    if (newCardAndBook.card) {
-      cardAndBook.card = newCardAndBook.card;
-      cardAndBook.book = newCardAndBook.book;
-    }
-    return cardAndBook;
-  },
-
-  editContact(win, name, email) {
-    let cardAndBook = DisplayNameUtils.getCardForEmail(email);
-    let args = {
-      abURI: cardAndBook.book.URI,
-      card: cardAndBook.card,
-    };
-    win.openDialog(
-      "chrome://messenger/content/addressbook/abEditCardDialog.xul",
-      "",
-      "chrome,modal,resizable=no,centerscreen",
-      args
-    );
-  },
-
   composeMessage(name, email, displayedFolder) {
     let dest =
       !name || name == email

--- a/addon/content/modules/conversation.js
+++ b/addon/content/modules/conversation.js
@@ -186,7 +186,7 @@ ViewWrapper.prototype = {
 // This is a workaround whilst we still have stub.xhtml being loaded in the
 // privileged scope. _ConversationUtils.getBrowser() simulates APIs and passes
 // them back to the webExtension process for handling by the real APIs.
-const SUPPORTED_BASE_APIS = ["tabs"];
+const SUPPORTED_BASE_APIS = ["convContacts", "tabs"];
 
 class _ConversationUtils {
   setBrowserListener(listener) {

--- a/addon/content/modules/conversation.js
+++ b/addon/content/modules/conversation.js
@@ -186,7 +186,12 @@ ViewWrapper.prototype = {
 // This is a workaround whilst we still have stub.xhtml being loaded in the
 // privileged scope. _ConversationUtils.getBrowser() simulates APIs and passes
 // them back to the webExtension process for handling by the real APIs.
-const SUPPORTED_BASE_APIS = ["convContacts", "tabs"];
+const SUPPORTED_BASE_APIS = [
+  "convContacts",
+  "conversations",
+  "messages",
+  "tabs",
+];
 
 class _ConversationUtils {
   setBrowserListener(listener) {
@@ -205,19 +210,6 @@ class _ConversationUtils {
       browser[api] = new Proxy({}, subApiHandler);
     }
     return browser;
-  }
-
-  markAllAsRead(msgUris, read, withChecks = false) {
-    if (
-      !withChecks ||
-      Services.prefs.getBoolPref("mailnews.mark_message_read.auto") ||
-      Services.prefs.getBoolPref("mailnews.mark_message_read.delay")
-    ) {
-      msgHdrsMarkAsRead(
-        msgUris.map(msg => msgUriToMsgHdr(msg)),
-        read
-      );
-    }
   }
 
   markAsJunk(win, isJunk) {

--- a/addon/content/modules/message.js
+++ b/addon/content/modules/message.js
@@ -93,10 +93,7 @@ let Log = setupLogging("Conversations.Message");
 // This is high because we want enough snippet to extract relevant data from
 // bugzilla snippets.
 const kSnippetLength = 700;
-const kViewerUrl = "chrome://conversations/content/pdfviewer/wrapper.xul?uri=";
 
-let makeViewerUrl = (name, url) =>
-  kViewerUrl + encodeURIComponent(url) + "&name=" + encodeURIComponent(name);
 const pdfMimeTypes = [
   "application/pdf",
   "application/x-pdf",
@@ -133,31 +130,6 @@ function dateAccordingToPref(date) {
 }
 
 class _MessageUtils {
-  setOpenTabListener(listener) {
-    this._openTabListener = listener;
-  }
-
-  openGallery(msgUri) {
-    if (!this._openTabListener) {
-      Log.error("No open tab listener!");
-      return;
-    }
-    this._openTabListener("/gallery/index.html?uri=" + encodeURI(msgUri));
-  }
-
-  previewAttachment(win, name, url, isPdf, maybeViewable) {
-    if (maybeViewable) {
-      win.document
-        .getElementById("tabmail")
-        .openTab("contentTab", { contentPage: url });
-    }
-    if (isPdf) {
-      win.document
-        .getElementById("tabmail")
-        .openTab("chromeTab", { chromePage: makeViewerUrl(name, url) });
-    }
-  }
-
   _getAttachmentInfo(win, msgUri, attachment) {
     const attInfo = new win.AttachmentInfo(
       attachment.contentType,

--- a/addon/content/reducer.js
+++ b/addon/content/reducer.js
@@ -418,11 +418,10 @@ function summary(state = initialSummary, action) {
       };
     }
     case "ADD_CONTACT": {
-      ContactHelpers.addContact(
-        topMail3Pane(window),
-        action.name,
-        action.email
-      );
+      browser.convContacts.beginNew({
+        email: action.email,
+        displayName: action.name,
+      });
       // TODO: In theory we should be updating the store so that the button can
       // then be updated to indicate this is now in the address book. However,
       // until we start getting the full conversation messages hooked up, this
@@ -439,11 +438,9 @@ function summary(state = initialSummary, action) {
       return state;
     }
     case "EDIT_CONTACT": {
-      ContactHelpers.editContact(
-        topMail3Pane(window),
-        action.name,
-        action.email
-      );
+      browser.convContacts.beginEdit({
+        email: action.email,
+      });
       return state;
     }
     case "FORWARD_CONVERSATION": {

--- a/addon/content/reducer.js
+++ b/addon/content/reducer.js
@@ -4,7 +4,7 @@
 
 /* global Redux, Conversations, topMail3Pane, getMail3Pane,
           isInTab:true, openConversationInTabOrWindow,
-          printConversation */
+          printConversation, ConversationUtils */
 
 /* exported conversationApp */
 
@@ -18,7 +18,6 @@ XPCOMUtils.defineLazyModuleGetters(this, {
   openConversationInTabOrWindow:
     "chrome://conversations/content/modules/misc.js",
   MessageUtils: "chrome://conversations/content/modules/message.js",
-  ConversationUtils: "chrome://conversations/content/modules/conversation.js",
 });
 
 const initialAttachments = {};
@@ -95,7 +94,9 @@ function attachments(state = initialAttachments, action) {
       return state;
     }
     case "SHOW_GALLERY_VIEW": {
-      MessageUtils.openGallery(action.msgUri);
+      browser.tabs.create({
+        url: "/gallery/index.html?uri=" + encodeURI(action.msgUri),
+      });
       return state;
     }
     default: {

--- a/addon/content/stub.js
+++ b/addon/content/stub.js
@@ -41,6 +41,9 @@ const { topMail3Pane } = ChromeUtils.import(
 const { setupLogging, dumpCallStack } = ChromeUtils.import(
   "chrome://conversations/content/modules/log.js"
 );
+const { ConversationUtils } = ChromeUtils.import(
+  "chrome://conversations/content/modules/conversation.js"
+);
 
 Log = setupLogging("Conversations.Stub");
 // Declare with var, not let, so that it's in the global scope, not the lexical scope.
@@ -48,6 +51,11 @@ Log = setupLogging("Conversations.Stub");
 var isInTab = false;
 
 let oldPrint = window.print;
+
+// This provides simulation for the WebExtension environment whilst we're still
+// being loaded in a privileged process.
+/* exported browser */
+let browser = ConversationUtils.getBrowser();
 
 function printConversation(event) {
   for (let { message: m } of Conversations.currentConversation.messages) {

--- a/addon/experiment-api/contactsApi.js
+++ b/addon/experiment-api/contactsApi.js
@@ -1,0 +1,59 @@
+var { XPCOMUtils } = ChromeUtils.import(
+  "resource://gre/modules/XPCOMUtils.jsm"
+);
+
+XPCOMUtils.defineLazyModuleGetters(this, {
+  DisplayNameUtils: "resource:///modules/DisplayNameUtils.jsm",
+  ExtensionCommon: "resource://gre/modules/ExtensionCommon.jsm",
+  Services: "resource://gre/modules/Services.jsm",
+});
+
+/* exported convContacts */
+var convContacts = class extends ExtensionCommon.ExtensionAPI {
+  getAPI(context) {
+    const { extension } = context;
+    const { windowManager } = extension;
+    return {
+      convContacts: {
+        async beginNew(beginNewProperties) {
+          const window =
+            beginNewProperties.windowId !== null
+              ? windowManager.get(beginNewProperties.windowId, context).window
+              : Services.wm.getMostRecentWindow("mail:3pane");
+          const args = {};
+          if (beginNewProperties.email !== null) {
+            args.primaryEmail = beginNewProperties.email;
+          }
+          if (beginNewProperties.displayName !== null) {
+            args.displayName = beginNewProperties.displayName;
+          }
+          window.openDialog(
+            "chrome://messenger/content/addressbook/abNewCardDialog.xul",
+            "",
+            "chrome,resizable=no,titlebar,modal,centerscreen",
+            args
+          );
+        },
+        async beginEdit(beginEditProperties) {
+          const window =
+            beginEditProperties.windowId !== null
+              ? windowManager.get(beginEditProperties.windowId, context).window
+              : Services.wm.getMostRecentWindow("mail:3pane");
+          let cardAndBook = DisplayNameUtils.getCardForEmail(
+            beginEditProperties.email
+          );
+          const args = {
+            abURI: cardAndBook.book.URI,
+            card: cardAndBook.card,
+          };
+          window.openDialog(
+            "chrome://messenger/content/addressbook/abEditCardDialog.xul",
+            "",
+            "chrome,modal,resizable=no,centerscreen",
+            args
+          );
+        },
+      },
+    };
+  }
+};

--- a/addon/experiment-api/contactsSchema.json
+++ b/addon/experiment-api/contactsSchema.json
@@ -1,0 +1,66 @@
+[
+  {
+    "namespace": "convContacts",
+    "functions": [
+      {
+        "name": "beginNew",
+        "type": "function",
+        "description": "Temporary. Opens the address book new card dialog.",
+        "async": true,
+        "parameters": [
+          {
+            "type": "object",
+            "name": "beginNewProperties",
+            "properties": {
+              "email": {
+                "type": "string",
+                "optional": "true",
+                "description": "The email to add."
+              },
+              "displayName": {
+                "type": "string",
+                "optional": "true",
+                "description": "The display name to add for the contact."
+              },
+              "parentId": {
+                "type": "string",
+                "optional": "true",
+                "description": "The default parent address book (the user may change this),"
+              },
+              "windowId": {
+                "type": "integer",
+                "optional": true,
+                "minimum": -2,
+                "description": "The window to create the new tab in. Defaults to the current window."
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "beginEdit",
+        "type": "function",
+        "description": "Temporary. Opens the address book edit card dialog.",
+        "async": true,
+        "parameters": [
+          {
+            "type": "object",
+            "name": "beginEditProperties",
+            "properties": {
+              "email": {
+                "type": "string",
+                "description": "The contact email to edit."
+              },
+              "windowId": {
+                "type": "integer",
+                "optional": true,
+                "minimum": -2,
+                "description": "The window to create the new tab in. Defaults to the current window."
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/addon/experiment-api/schema.json
+++ b/addon/experiment-api/schema.json
@@ -103,14 +103,28 @@
     ],
     "events": [
       {
-        "name": "onOpenTab",
+        "name": "onCallAPI",
         "type": "function",
-        "description": "Temporary. Fires for selected actions to open a tab.",
+        "description": "Temporary. Fires the specified API.",
         "parameters": [
           {
-            "name": "page",
+            "name": "apiName",
             "type": "string",
-            "description": "Temporary. The page and query uri (if appropriate) to open."
+            "description": "The general of the API to call (e.g. 'tabs' for 'browser.tabs')."
+          },
+          {
+            "name": "apiItem",
+            "type": "string",
+            "description": "The name of the API to call."
+          },
+          {
+            "name": "args",
+            "type": "array",
+            "optional": true,
+            "items": {
+              "type": "any"
+            },
+            "description": "The arguments to call."
           }
         ]
       }

--- a/addon/experiment-api/schema.json
+++ b/addon/experiment-api/schema.json
@@ -99,6 +99,28 @@
             "description": "The size to format"
           }
         ]
+      },
+      {
+        "name": "createTab",
+        "type": "function",
+        "description": "Temporary. Creates a content or chrome tab. What we'll need to replace with depends on Message Attachments API",
+        "async": "true",
+        "parameters": [
+          {
+            "name": "createTabProperties",
+            "type": "object",
+            "properties": {
+              "url": {
+                "type": "string",
+                "description": "The url to open"
+              },
+              "type": {
+                "type": "string",
+                "description": "The type of tab to open."
+              }
+            }
+          }
+        ]
       }
     ],
     "events": [

--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -22,7 +22,7 @@
     "open_in_tab": true,
     "page": "options.html"
   },
-  "permissions": ["addressBooks", "messagesRead", "storage"],
+  "permissions": ["addressBooks", "messagesRead", "messagesMove", "storage"],
   "experiment_apis": {
     "conversations": {
       "schema": "experiment-api/schema.json",

--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -22,7 +22,7 @@
     "open_in_tab": true,
     "page": "options.html"
   },
-  "permissions": ["messagesRead", "storage"],
+  "permissions": ["addressBooks", "messagesRead", "storage"],
   "experiment_apis": {
     "conversations": {
       "schema": "experiment-api/schema.json",
@@ -36,6 +36,20 @@
           ]
         ],
         "script": "experiment-api/api.js"
+      }
+    },
+    "convContacts": {
+      "schema": "experiment-api/contactsSchema.json",
+      "parent": {
+        "scopes": [
+          "addon_parent"
+        ],
+        "paths": [
+          [
+            "convContacts"
+          ]
+        ],
+        "script": "experiment-api/contactsApi.js"
       }
     }
   },

--- a/addon/options.css
+++ b/addon/options.css
@@ -29,3 +29,10 @@ body {
 h1 {
   text-align: center;
 }
+
+button {
+  display: block;
+  font-size: 1em;
+  margin: 0.5em auto;
+  padding: 0.5em;
+}

--- a/addon/options.jsx
+++ b/addon/options.jsx
@@ -181,6 +181,12 @@ function localize(prefsInfo, i18n = browser.i18n) {
   throw new Error("Don't know how to localize the object", prefsInfo);
 }
 
+function openSetupAssistant() {
+  browser.tabs.create({
+    url: "assistant/assistant.html",
+  });
+}
+
 //
 // React components to render the options types
 //
@@ -358,8 +364,10 @@ BinaryOption.propTypes = {
 function _ConversationOptions({
   localizedPrefsInfo,
   localizedName,
+  localizedStartAssistant,
   prefs,
   setPref,
+  startSetupAssistant,
 }) {
   return (
     <React.Fragment>
@@ -376,14 +384,17 @@ function _ConversationOptions({
           ))}
         </div>
       </form>
+      <button onClick={startSetupAssistant}>{localizedStartAssistant}</button>
     </React.Fragment>
   );
 }
 _ConversationOptions.propTypes = {
   localizedPrefsInfo: PropTypes.array.isRequired,
   localizedName: PropTypes.string.isRequired,
+  localizedStartAssistant: PropTypes.string.isRequired,
   prefs: PropTypes.object.isRequired,
   setPref: PropTypes.func.isRequired,
+  startSetupAssistant: PropTypes.func.isRequired,
 };
 
 const ConversationOptions = ReactRedux.connect(state => ({ prefs: state }), {
@@ -397,6 +408,9 @@ export function Main() {
   );
   const [localizedPrefsInfo, setLocalizedPrefsInfo] = React.useState(
     localize(PREFS_INFO, i18n)
+  );
+  const [localizedStartAssistant, setLocalizedStartAssistant] = React.useState(
+    localize("options.start_setup_assistant", i18n)
   );
 
   // When the i18n library is loaded, we want to translate all
@@ -412,6 +426,9 @@ export function Main() {
       .then(() => {
         setLocalizedName(localize("extensionName", i18n));
         setLocalizedPrefsInfo(localize(PREFS_INFO, i18n));
+        setLocalizedStartAssistant(
+          localize("options.start_setup_assistant", i18n)
+        );
       })
       .catch(e => {
         throw e;
@@ -423,6 +440,8 @@ export function Main() {
       <ConversationOptions
         localizedPrefsInfo={localizedPrefsInfo}
         localizedName={localizedName}
+        localizedStartAssistant={localizedStartAssistant}
+        startSetupAssistant={openSetupAssistant}
       />
     </ReactRedux.Provider>
   );

--- a/addon/tests/options.test.jsx
+++ b/addon/tests/options.test.jsx
@@ -144,4 +144,20 @@ describe("Option full page tests", () => {
     const afterChange = mockedSet.mock.calls.pop();
     expect(afterChange[0]).toMatchObject({ preferences: { [name]: true } });
   });
+
+  test("Pressing the button opens the setup assistant", async () => {
+    const mockedTabCreate = jest.spyOn(browser.tabs, "create");
+    const main = enzyme.mount(<Main />);
+
+    waitForComponentToPaint(main);
+
+    const button = main.find("button");
+
+    button.simulate("click");
+
+    expect(mockedTabCreate).toHaveBeenCalled();
+    expect(mockedTabCreate.mock.calls[0][0]).toStrictEqual({
+      url: "assistant/assistant.html",
+    });
+  });
 });


### PR DESCRIPTION
I realised that by exposing some extra APIs and doing a little extra work, that we could expose `browser` object to stub.xhtml that simulates the `browser` object that WebExtensions have.

We do this by registering the WebExtension part with an experimental API event, which then is used as a callback mechanism, so that calls to the `browser` object in stub.xhtml call back to the real `browser` object.

My intention is to allow us to start moving things in stub.xhtml across to use WebExtension APIs "directly". Hence we can progressively move across the direct calls to use WebExtension APIs - this should make it easier once we get to the final transition stage of moving the whole page to be a webExtension page (hopefully that'll work).

@siefkenj I thought you might be interested in this, as I think this lays the groundwork for things later. I'm planning on doing a little bit more work this weekend - to move the obvious create tab calls across and do a bit more work on the contacts side - before I land this.