### PR TITLE
Encapsulate all svg rendering into SvgIcon

### DIFF
--- a/addon/content/attachments.jsx
+++ b/addon/content/attachments.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-/* globals PropTypes, React */
+/* globals PropTypes, React, SvgIcon */
 /* exported Attachments */
 
 class Attachment extends React.PureComponent {
@@ -149,14 +149,7 @@ class Attachment extends React.PureComponent {
                 title={this.props.strings.get("preview")}
                 onClick={this.preview}
               >
-                <svg
-                  className="icon"
-                  viewBox="0 0 24 24"
-                  xmlns="http://www.w3.org/2000/svg"
-                  xmlnsXlink="http://www.w3.org/1999/xlink"
-                >
-                  <use xlinkHref="chrome://conversations/skin/material-icons.svg#visibility"></use>
-                </svg>
+                <SvgIcon hash={"visibility"} />
               </a>
             )}
             <a
@@ -164,28 +157,14 @@ class Attachment extends React.PureComponent {
               title={this.props.strings.get("download2")}
               onClick={this.downloadAttachment}
             >
-              <svg
-                className="icon"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlnsXlink="http://www.w3.org/1999/xlink"
-              >
-                <use xlinkHref="chrome://conversations/skin/material-icons.svg#file_download"></use>
-              </svg>
+              <SvgIcon hash={"file_download"} />
             </a>
             <a
               className="icon-link open-attachment"
               title={this.props.strings.get("open")}
               onClick={this.openAttachment}
             >
-              <svg
-                className="icon"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlnsXlink="http://www.w3.org/1999/xlink"
-              >
-                <use xlinkHref="chrome://conversations/skin/material-icons.svg#search"></use>
-              </svg>
+              <SvgIcon hash={"search"} />
             </a>
           </div>
         </div>
@@ -270,14 +249,7 @@ class Attachments extends React.PureComponent {
             onClick={this.downloadAll}
             title={this.props.strings.get("downloadAll2")}
           >
-            <svg
-              className="icon"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-              xmlnsXlink="http://www.w3.org/1999/xlink"
-            >
-              <use xlinkHref="chrome://conversations/skin/material-icons.svg#file_download"></use>
-            </svg>
+            <SvgIcon hash={"file_download"} />
           </a>
           {this.props.gallery && (
             <a
@@ -285,14 +257,7 @@ class Attachments extends React.PureComponent {
               className="icon-link view-all"
               title={this.props.strings.get("galleryView")}
             >
-              <svg
-                className="icon"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlnsXlink="http://www.w3.org/1999/xlink"
-              >
-                <use xlinkHref="chrome://conversations/skin/material-icons.svg#photo_library"></use>
-              </svg>
+              <SvgIcon hash={"photo_library"} />
             </a>
           )}
           {this.props.attachments.map(attachment => (

--- a/addon/content/contactDetail.jsx
+++ b/addon/content/contactDetail.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-/* globals PropTypes, React, ReactDOM, ReactRedux, StringBundle */
+/* globals PropTypes, React, ReactDOM, ReactRedux, StringBundle, SvgIcon */
 /* exported ContactDetail */
 
 class _ContactDetail extends React.PureComponent {
@@ -116,14 +116,7 @@ class _ContactDetail extends React.PureComponent {
                 title={this.strings.get("copyEmail")}
                 onClick={this.copyEmail}
               >
-                <svg
-                  className="icon"
-                  viewBox="0 0 24 24"
-                  xmlns="http://www.w3.org/2000/svg"
-                  xmlnsXlink="http://www.w3.org/1999/xlink"
-                >
-                  <use xlinkHref="chrome://conversations/skin/material-icons.svg#content_copy"></use>
-                </svg>
+                <SvgIcon hash={"content_copy"} />
               </button>
             </span>
           </div>
@@ -137,28 +130,14 @@ class _ContactDetail extends React.PureComponent {
             title={this.strings.get("sendEmail")}
             onClick={this.sendEmail}
           >
-            <svg
-              className="icon"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-              xmlnsXlink="http://www.w3.org/1999/xlink"
-            >
-              <use xlinkHref="chrome://conversations/skin/material-icons.svg#mail"></use>
-            </svg>
+            <SvgIcon hash={"mail"} />
           </button>
           <button
             className="showInvolving"
             title={this.strings.get("recentConversations")}
             onClick={this.showInvolving}
           >
-            <svg
-              className="icon"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-              xmlnsXlink="http://www.w3.org/1999/xlink"
-            >
-              <use xlinkHref="chrome://conversations/skin/material-icons.svg#history"></use>
-            </svg>
+            <SvgIcon hash={"history"} />
           </button>
           {this.props.hasCard ? (
             <button
@@ -166,14 +145,7 @@ class _ContactDetail extends React.PureComponent {
               title={this.strings.get("editCardAb")}
               onClick={this.editContact}
             >
-              <svg
-                className="icon"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlnsXlink="http://www.w3.org/1999/xlink"
-              >
-                <use xlinkHref="chrome://conversations/skin/material-icons.svg#edit"></use>
-              </svg>
+              <SvgIcon hash={"edit"} />
             </button>
           ) : (
             <button
@@ -181,14 +153,7 @@ class _ContactDetail extends React.PureComponent {
               title={this.strings.get("addToAb")}
               onClick={this.addContact}
             >
-              <svg
-                className="icon"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlnsXlink="http://www.w3.org/1999/xlink"
-              >
-                <use xlinkHref="chrome://conversations/skin/material-icons.svg#add"></use>
-              </svg>
+              <SvgIcon hash={"add"} />
             </button>
           )}
           <button className="createFilter" onClick={this.createFilter}>

--- a/addon/content/conversationHeader.jsx
+++ b/addon/content/conversationHeader.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-/* globals React, ReactRedux, PropTypes */
+/* globals React, ReactRedux, PropTypes, SvgIcon */
 /* exported ConversationHeader */
 
 const LINKS_REGEX = /((\w+):\/\/[^<>()'"\s]+|www(\.[-\w]+){2,})/;
@@ -177,28 +177,14 @@ class _ConversationHeader extends React.PureComponent {
               title={this.props.strings.get("stub.trash.tooltip")}
               onClick={this.delete}
             >
-              <svg
-                className="icon"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlnsXlink="http://www.w3.org/1999/xlink"
-              >
-                <use xlinkHref="chrome://conversations/skin/material-icons.svg#delete"></use>
-              </svg>
+              <SvgIcon hash={"delete"} />
             </button>
             <button
               className="button-flat"
               title={this.props.strings.get("stub.archive.tooltip")}
               onClick={this.archiveToolbar}
             >
-              <svg
-                className="icon"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlnsXlink="http://www.w3.org/1999/xlink"
-              >
-                <use xlinkHref="chrome://conversations/skin/material-icons.svg#archive"></use>
-              </svg>
+              <SvgIcon hash={"archive"} />
             </button>
             {this.canJunk && (
               <button
@@ -206,14 +192,7 @@ class _ConversationHeader extends React.PureComponent {
                 title={this.props.strings.get("stub.junk.tooltip")}
                 onClick={this.junkConversation}
               >
-                <svg
-                  className="icon"
-                  viewBox="0 0 24 24"
-                  xmlns="http://www.w3.org/2000/svg"
-                  xmlnsXlink="http://www.w3.org/1999/xlink"
-                >
-                  <use xlinkHref="chrome://conversations/skin/material-icons.svg#whatshot"></use>
-                </svg>
+                <SvgIcon hash={"whatshot"} />
               </button>
             )}
             <button
@@ -244,30 +223,14 @@ class _ConversationHeader extends React.PureComponent {
               title={this.props.strings.get("stub.read.tooltip")}
               onClick={this.toggleRead}
             >
-              <svg
-                className={`icon read ${
-                  this.areSomeMessagesUnread ? "unread" : ""
-                }`}
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlnsXlink="http://www.w3.org/1999/xlink"
-              >
-                <use xlinkHref="chrome://conversations/skin/material-icons.svg#new"></use>
-              </svg>
+              <SvgIcon hash={"new"} />
             </button>
             <button
               className="button-flat"
               title={this.props.strings.get("stub.detach.tooltip2")}
               onClick={this.detachTab}
             >
-              <svg
-                className="icon"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlnsXlink="http://www.w3.org/1999/xlink"
-              >
-                <use xlinkHref="chrome://conversations/skin/material-icons.svg#open_in_new"></use>
-              </svg>
+              <SvgIcon hash={"open_in_new"} />
             </button>
           </div>
         </div>

--- a/addon/content/es-modules/components/svg-icon.js
+++ b/addon/content/es-modules/components/svg-icon.js
@@ -17,8 +17,6 @@
 // Make sure all the libraries that need to be in global scope are in global scope.
 import { React, ReactDOM, Redux, ReactRedux, RTK, PropTypes } from "../ui.js";
 Object.assign(window, { React, ReactDOM, Redux, ReactRedux, RTK, PropTypes });
-import { SvgIcon } from "./svg-icon.js";
-Object.assign(window, { SvgIcon });
 
 // Set up an object for the make-shift module emulation
 window.esExports = {};
@@ -26,9 +24,6 @@ window.esExports = {};
 // The node.js `esm` loader won't share globals. Since this is only used
 // by tests at the moment, which are run by node.js, use the `require`
 // function as a fallback
-require("../../messageTags.js");
+require("../../svgIcon.js");
 
-export const MessageTag = window.esExports.MessageTag;
-export const MessageTags = window.esExports.MessageTags;
-export const SpecialMessageTag = window.esExports.SpecialMessageTag;
-export const SpecialMessageTags = window.esExports.SpecialMessageTags;
+export const SvgIcon = window.esExports.SvgIcon;

--- a/addon/content/messageActionButton.jsx
+++ b/addon/content/messageActionButton.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-/* globals PropTypes, React, StringBundle */
+/* globals PropTypes, React, StringBundle, SvgIcon */
 /* exported ActionButton */
 
 const ActionsToInfoMap = {
@@ -86,17 +86,7 @@ class ActionButton extends React.PureComponent {
         title={title}
         onClick={this.action}
       >
-        <svg
-          className="icon"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-          xmlnsXlink="http://www.w3.org/1999/xlink"
-        >
-          <use
-            xlinkHref={`chrome://conversations/skin/material-icons.svg#${info.icon}`}
-          ></use>
-        </svg>{" "}
-        {!!this.props.showString && title}
+        <SvgIcon hash={info.icon} /> {!!this.props.showString && title}
       </button>
     );
   }

--- a/addon/content/messageHeader.jsx
+++ b/addon/content/messageHeader.jsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /* globals React, PropTypes, MessageHeaderOptions, StringBundle, MessageTags
-           SpecialMessageTags, ContactDetail */
+           SpecialMessageTags, ContactDetail, SvgIcon */
 /* exported MessageHeader */
 
 class Fade extends React.PureComponent {
@@ -251,14 +251,7 @@ class MessageHeader extends React.PureComponent {
             className={"star" + (this.props.starred ? " starred" : "")}
             onClick={this.onClickStar}
           >
-            <svg
-              className="icon"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-              xmlnsXlink="http://www.w3.org/1999/xlink"
-            >
-              <use xlinkHref="chrome://conversations/skin/material-icons.svg#star"></use>
-            </svg>
+            <SvgIcon hash={"star"} />
           </div>
           {this.props.from.avatarIsDefault ? (
             <abbr

--- a/addon/content/messageHeaderOptions.jsx
+++ b/addon/content/messageHeaderOptions.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-/* globals PropTypes, React, StringBundle, ActionButton */
+/* globals PropTypes, React, StringBundle, ActionButton, SvgIcon */
 /* exported MessageHeaderOptions */
 
 class OptionsMoreMenu extends React.PureComponent {
@@ -201,14 +201,7 @@ class MessageHeaderOptions extends React.PureComponent {
       <div className="options">
         {!!this.props.attachments.length && (
           <span className="attachmentIcon">
-            <svg
-              className="icon"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-              xmlnsXlink="http://www.w3.org/1999/xlink"
-            >
-              <use xlinkHref="chrome://conversations/skin/material-icons.svg#attachment"></use>
-            </svg>
+            <SvgIcon hash={"attachment"} />
           </span>
         )}
         <span className="date">
@@ -238,20 +231,9 @@ class MessageHeaderOptions extends React.PureComponent {
                   : this.strings.get("details")
               }
             >
-              <svg
-                className="icon"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlnsXlink="http://www.w3.org/1999/xlink"
-              >
-                <use
-                  xlinkHref={
-                    this.props.detailsShowing
-                      ? "chrome://conversations/skin/material-icons.svg#info"
-                      : "chrome://conversations/skin/material-icons.svg#info_outline"
-                  }
-                ></use>
-              </svg>
+              <SvgIcon
+                hash={this.props.detailsShowing ? "info" : "info_outline"}
+              />
             </a>
           </span>
         )}
@@ -262,14 +244,7 @@ class MessageHeaderOptions extends React.PureComponent {
               className="icon-link top-right-more"
               title={this.strings.get("more")}
             >
-              <svg
-                className="icon"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-                xmlnsXlink="http://www.w3.org/1999/xlink"
-              >
-                <use xlinkHref="chrome://conversations/skin/material-icons.svg#more_vert"></use>
-              </svg>
+              <SvgIcon hash={"more_vert"} />
             </button>
             {this.state.expanded && (
               <OptionsMoreMenu

--- a/addon/content/messageNotification.jsx
+++ b/addon/content/messageNotification.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-/* globals PropTypes, React */
+/* globals PropTypes, React, SvgIcon */
 /* exported MessageNotification */
 
 class RemoteContentNotification extends React.PureComponent {
@@ -58,16 +58,7 @@ class GenericSingleButtonNotification extends React.PureComponent {
   render() {
     return (
       <div className={this.props.barClassName + " notificationBar"}>
-        <svg
-          className="icon"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-          xmlnsXlink="http://www.w3.org/1999/xlink"
-        >
-          <use
-            xlinkHref={`chrome://conversations/skin/material-icons.svg#${this.props.iconName}`}
-          ></use>
-        </svg>
+        <SvgIcon hash={this.props.iconName} />
         {this.props.notificationText}{" "}
         <span className={this.props.buttonClassName}>
           <a onClick={this.props.onButtonClick}>{this.props.buttonTitle}</a>
@@ -104,16 +95,7 @@ class GenericMultiButtonNotification extends React.PureComponent {
   render() {
     return (
       <div className={this.props.barClassName + " notificationBar"}>
-        <svg
-          className="icon"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-          xmlnsXlink="http://www.w3.org/1999/xlink"
-        >
-          <use
-            xlinkHref={`chrome://conversations/skin/material-icons.svg#${this.props.iconName}`}
-          ></use>
-        </svg>
+        <SvgIcon hash={this.props.iconName} />
         {this.props.notificationText}{" "}
         {this.props.buttons.map((button, i) => (
           <button

--- a/addon/content/messageTags.jsx
+++ b/addon/content/messageTags.jsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-/* globals React, PropTypes */
+/* globals React, PropTypes, SvgIcon */
 /* exported MessageTags, SpecialMessageTags */
 
 /**
@@ -76,21 +76,6 @@ MessageTags.propTypes = {
   onTagsChange: PropTypes.func.isRequired,
 };
 
-function Icon(props) {
-  const { path } = props;
-  return (
-    <svg
-      className="icon"
-      viewBox="0 0 24 24"
-      xmlns="http://www.w3.org/2000/svg"
-      xmlnsXlink="http://www.w3.org/1999/xlink"
-    >
-      <use xlinkHref={path}></use>
-    </svg>
-  );
-}
-Icon.propTypes = { path: PropTypes.string.isRequired };
-
 function DkimTooltip({ strings }) {
   const [primaryString, secondaryStrings = []] = strings;
   const primaryTooltip = <div>{primaryString}</div>;
@@ -127,7 +112,7 @@ function SpecialMessageTag({
       title={title}
       onClick={onClick}
     >
-      <Icon path={icon} />
+      <SvgIcon fullPath={icon} />
       {name}
       {tooltip.type === "dkim" && <DkimTooltip strings={tooltip.strings} />}
     </li>

--- a/addon/content/stub.xhtml
+++ b/addon/content/stub.xhtml
@@ -26,6 +26,7 @@
   <script type="text/javascript" src="vendor/reactjs-popup.js"></script>
   <script type="text/javascript" src="vendor/prop-types.js"></script>
   <script type="text/javascript" src="reducer.js"></script>
+  <script type="text/javascript" src="svgIcon.js"></script>
   <script type="text/javascript" src="attachments.js"></script>
   <script type="text/javascript" src="conversationHeader.js"></script>
   <script type="text/javascript" src="conversationFooter.js"></script>

--- a/addon/content/svgIcon.jsx
+++ b/addon/content/svgIcon.jsx
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/* globals PropTypes, React */
+/* exported SvgIcon */
+
+/**
+ * A basic SVG icon rendered using the `xlinkHref` ability
+ * of SVGs. You can specify the full path, or just the hash.
+ *
+ * @param {*} { fullPath, hash }
+ * @returns {React.ReactNode}
+ */
+function SvgIcon({ fullPath, hash }) {
+  fullPath =
+    fullPath || `chrome://conversations/skin/material-icons.svg#${hash}`;
+  return (
+    <svg
+      className="icon"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+    >
+      <use xlinkHref={fullPath}></use>
+    </svg>
+  );
+}
+SvgIcon.propTypes = { fullPath: PropTypes.string, hash: PropTypes.string };
+
+// This is temporary code to allow using using this as both
+// an es-module and as-is with global variables. This code
+// should be removed when the transition to a WebExtension is
+// complete.
+
+if (window.esExports) {
+  window.esExports.SvgIcon = SvgIcon;
+}

--- a/addon/tests/svgIcon.test.jsx
+++ b/addon/tests/svgIcon.test.jsx
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+/* eslint-env jest */
+
+// Standard imports for all tests
+const { esmImport, enzyme, React } = require("./utils");
+
+// Import the components we want to test
+const { SvgIcon } = esmImport("../content/es-modules/components/svg-icon.js");
+
+describe("SvgIcon test", () => {
+  test("renders given a full path", async () => {
+    const PATH = "/full/path/to/icon";
+    const wrapper = enzyme.mount(<SvgIcon fullPath={PATH} />);
+
+    expect(wrapper.find("use").html()).toMatch(PATH);
+  });
+
+  test("renders given a hash", async () => {
+    const HASH = "abc";
+    const wrapper = enzyme.mount(<SvgIcon hash={HASH} />);
+
+    expect(wrapper.find("use").html()).toMatch("#" + HASH);
+  });
+});


### PR DESCRIPTION
An `SvgIcon` component was added and all (save one) direct references to the `material-icon.svg` file have been abstracted away to `SvgIcon`.

*Very* basic rendering test has been added.