### PR TITLE
Replace Redux.createStore with RTK.configureStore

### DIFF
--- a/addon/content/messageIFrame.jsx
+++ b/addon/content/messageIFrame.jsx
@@ -37,10 +37,7 @@ class MessageIFrame extends React.Component {
     // want to scroll the message to view, since the user may be viewing somewhere
     // else.
     this.dueToExpansion = undefined;
-    if (
-      prevProps.neckoUrl.spec != this.props.neckoUrl.spec &&
-      this.props.expanded
-    ) {
+    if (prevProps.neckoUrl != this.props.neckoUrl && this.props.expanded) {
       // This is a hack which ensures that the iframe is a minimal height, so
       // that when the message loads, the scroll height is set correctly, rather
       // than to the potential height of the previously loaded message.
@@ -68,7 +65,7 @@ class MessageIFrame extends React.Component {
       // If we're changing URL, then also force the iframe to be about:blank.
       // This ensures that if the message is subsequently expanded, the proper
       // notifications are sent.
-      if (prevProps.neckoUrl.spec != this.props.neckoUrl.spec) {
+      if (prevProps.neckoUrl != this.props.neckoUrl) {
         this.iframe.src = "about:blank";
         this.currentUrl = "about:blank";
       }
@@ -82,7 +79,6 @@ class MessageIFrame extends React.Component {
         docshell: this.iframe.contentWindow.docShell,
         dueToExpansion: this.dueToExpansion,
         msgUri: this.props.msgUri,
-        neckoUrl: this.props.neckoUrl,
       });
     }
   }
@@ -116,7 +112,6 @@ class MessageIFrame extends React.Component {
         type: "MSG_STREAM_MSG",
         docshell: docShell,
         msgUri: this.props.msgUri,
-        neckoUrl: this.props.neckoUrl,
       });
     } else {
       this.iframe.classList.add("hidden");
@@ -442,7 +437,7 @@ MessageIFrame.propTypes = {
   hasRemoteContent: PropTypes.bool.isRequired,
   initialPosition: PropTypes.number.isRequired,
   msgUri: PropTypes.string.isRequired,
-  neckoUrl: PropTypes.object.isRequired,
+  neckoUrl: PropTypes.string.isRequired,
   prefs: PropTypes.object.isRequired,
   realFrom: PropTypes.string.isRequired,
   strings: PropTypes.object.isRequired,

--- a/addon/content/modules/conversation.js
+++ b/addon/content/modules/conversation.js
@@ -902,7 +902,7 @@ Conversation.prototype = {
     this._htmlPane.conversationDispatch({
       type: "REPLACE_CONVERSATION_DETAILS",
       summary: {
-        conversation: this,
+        conversation: { getMessage: uri => this.getMessage(uri) },
         subject: this.messages[this.messages.length - 1].message.subject,
         loading: false,
         prefs: {

--- a/addon/content/modules/message.js
+++ b/addon/content/modules/message.js
@@ -416,7 +416,7 @@ class Message {
       isPhishing: this.isPhishing,
       msgUri: this._uri,
       multipleRecipients: this.isReplyAllEnabled,
-      neckoUrl: msgHdrToNeckoURL(this._msgHdr),
+      neckoUrl: msgHdrToNeckoURL(this._msgHdr).spec,
       read: this.read,
       realFrom: this._realFrom.email || this._from.email,
       recipientsIncludeLists: this.isReplyListEnabled,

--- a/addon/content/stub.js
+++ b/addon/content/stub.js
@@ -4,10 +4,32 @@
 
 /* import-globals-from quickReply.js */
 /* import-globals-from reducer.js */
-/* global Redux, ReactDOM, React, ReactRedux, ConversationWrapper,
+/* global RTK, ReactDOM, React, ReactRedux, ConversationWrapper,
           masqueradeAsQuickCompose */
 
-let store;
+const store = RTK.configureStore({
+  reducer: conversationApp,
+  // XXX bug #1461. Remove this code when that bug is resolved.
+  //
+  // By default RTK includes the serializableCheck
+  // Redux middleware which makes sure the Redux state
+  // and all Redux actions are serializable. We want this to
+  // be the case in the long run, but there are a few places
+  // where it will take more work to eliminate the non-serializable
+  // data. As a temporary workaround, exclude that data from the
+  // checks.
+  middleware: RTK.getDefaultMiddleware({
+    serializableCheck: {
+      ignoredActions: [
+        "MSG_STREAM_MSG",
+        "MSG_STREAM_LOAD_FINISHED",
+        "REPLACE_CONVERSATION_DETAILS",
+      ],
+      ignoredPaths: ["summary.conversation"],
+    },
+  }),
+});
+
 var { StringBundle } = ChromeUtils.import(
   "resource:///modules/StringBundle.js"
 );
@@ -70,8 +92,6 @@ document.documentElement.setAttribute("dir", direction);
 document.addEventListener(
   "DOMContentLoaded",
   () => {
-    store = Redux.createStore(conversationApp);
-
     const conversationContainer = document.getElementById(
       "conversationWrapper"
     );

--- a/addon/content/stub.xhtml
+++ b/addon/content/stub.xhtml
@@ -23,6 +23,7 @@
   <script type="text/javascript" src="vendor/react-dom.js"></script>
   <script type="text/javascript" src="vendor/redux.js"></script>
   <script type="text/javascript" src="vendor/react-redux.js"></script>
+  <script type="text/javascript" src="vendor/redux-toolkit.umd.js"></script>
   <script type="text/javascript" src="vendor/reactjs-popup.js"></script>
   <script type="text/javascript" src="vendor/prop-types.js"></script>
   <script type="text/javascript" src="reducer.js"></script>


### PR DESCRIPTION
`RTK.configureStore` has many advantages over `createStore`. For example, it automatically includes the `redux-thunk` middleware. It also includes serializability checks by default. 

The core of Conversations relies a few actions that pass non-serializable data. It will take some time to rework those components. Minimal exceptions were added for those actions. These exceptions should be removed when issue #1461 is resolved.