### PR TITLE
fix: enable attachment drag and drop support

### DIFF
--- a/addon/content/components/message/attachments.mjs
+++ b/addon/content/components/message/attachments.mjs
@@ -109,32 +109,56 @@ function Attachment({
     );
   }
 
-  // TODO: Fix drag n drop of attachments.
-  // onDragStart(event) {
-  //   let info;
-  //   if (/(^file:|&filename=)/.test(this.props.url)) {
-  //     info = this.props.url;
-  //   } else {
-  //     info =
-  //       this.props.url +
-  //       "&type=" +
-  //       this.props.contentType +
-  //       "&filename=" +
-  //       encodeURIComponent(this.props.name);
-  //   }
-  //   event.dataTransfer.setData(
-  //     "text/x-moz-url",
-  //     `${info}\n${this.props.name}\n${this.props.size}`
-  //   );
-  //   event.dataTransfer.setData("text/x-moz-url-data", this.props.url);
-  //   event.dataTransfer.setData("text/x-moz-url-desc", this.props.name);
-  //   event.dataTransfer.setData(
-  //     "application/x-moz-file-promise-url",
-  //     this.props.url
-  //   );
-  //   event.dataTransfer.setData("application/x-moz-file-promise", null);
-  //   event.stopPropagation();
-  // }
+  let [fileData, setFileData] = React.useState(null);
+  let [thumb, setThumb] = React.useState(null);
+  let [imgClass, setImgClass] = React.useState(null);
+
+  React.useEffect(() => {
+    if (isDeleted) {
+      return;
+    }
+    let url = null;
+    (async () => {
+      try {
+        let file = await browser.messages.getAttachmentFile(id, partName);
+        url = URL.createObjectURL(file);
+        setFileData({ file, url });
+        if (isImage) {
+          setThumb(url);
+          setImgClass("resize-me");
+        }
+      } catch (e) {
+        console.error(e);
+      }
+    })();
+    return () => {
+      if (url) {
+        URL.revokeObjectURL(url);
+      }
+    };
+  }, [id, partName, isImage, isDeleted]);
+
+  React.useEffect(() => {
+    if (!isImage) {
+      setThumb("../content/icons/" + iconForMimeType(contentType));
+      setImgClass("mime-icon");
+    }
+  }, [contentType, isImage]);
+
+  function onDragStart(event) {
+    if (!fileData) {
+      return;
+    }
+    const { file, url } = fileData;
+    event.dataTransfer.setData("DownloadURL", `${contentType}:${name}:${url}`);
+    try {
+      event.dataTransfer.items.add(file);
+    } catch (e) {
+      console.error(e);
+    }
+    event.dataTransfer.setData("text/x-moz-url", `${url}\n${name}`);
+    event.dataTransfer.setData("text/plain", name);
+  }
 
   function downloadAttachment() {
     dispatch(
@@ -224,29 +248,13 @@ function Attachment({
     ? browser.i18n.getMessage("attachments.viewAttachment.tooltip")
     : browser.i18n.getMessage("attachments.open.tooltip");
 
-  let [thumb, setThumb] = React.useState(null);
-  let [imgClass, setImgClass] = React.useState(null);
-  React.useEffect(() => {
-    if (isImage) {
-      // TODO: Can we load images separately and make them available later,
-      // so that we're not relying on having the url here. This would
-      // mean we can use browser.messages.listAttachments.
-      (async () => {
-        let file = await browser.messages.getAttachmentFile(id, partName);
-        setThumb(URL.createObjectURL(file));
-        setImgClass("resize-me");
-      })();
-    } else {
-      setThumb("../content/icons/" + iconForMimeType(contentType));
-      setImgClass("mime-icon");
-    }
-  }, [id, contentType, partName]);
-
-  // TODO: Drag n drop
-  // onDragStart={this.onDragStart}
   return React.createElement(
     "li",
-    { className: "attachment" },
+    {
+      className: "attachment",
+      draggable: !isDeleted && !!fileData ? "true" : "false",
+      onDragStart: !isDeleted && fileData ? onDragStart : null,
+    },
     isDeleted &&
       React.createElement(
         "div",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "thunderbird-conversations",
+  "name": "app",
   "version": "4.3.10",
   "lockfileVersion": 3,
   "requires": true,
@@ -1407,9 +1407,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1424,9 +1421,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1441,9 +1435,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1458,9 +1449,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1475,9 +1463,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1492,9 +1477,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1509,9 +1491,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1526,9 +1505,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1543,9 +1519,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1560,9 +1533,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [


### PR DESCRIPTION
Fetches the File object for all non-deleted attachments, sets up standard HTML5 and gecko-specific drag and drop properties on dragstart, and marks the attachment list item as draggable.